### PR TITLE
Fix .ctors linking

### DIFF
--- a/common.py
+++ b/common.py
@@ -99,7 +99,7 @@ ANALYSER = f"{PYTHON} {PPCDIS}/analyser.py"
 DISASSEMBLER = f"{PYTHON} {PPCDIS}/disassembler.py"
 ORDERSTRINGS = f"{PYTHON} {PPCDIS}/orderstrings.py"
 ORDERFLOATS = f"{PYTHON} {PPCDIS}/orderfloats.py"
-FORCEACTIVE = f"{PYTHON} {PPCDIS}/forceactive.py"
+FORCEFILESGEN = f"{PYTHON} {PPCDIS}/forcefilesgen.py"
 ELF2DOL = f"{PYTHON} {PPCDIS}/elf2dol.py"
 SLICES = f"{PYTHON} {PPCDIS}/slices.py"
 
@@ -143,7 +143,8 @@ DOL_LABELS = f"{BUILDDIR}/labels.pickle"
 DOL_RELOCS = f"{BUILDDIR}/relocs.pickle"
 
 # Linker
-DOL_LCF = f"{CONFIG}/dol.lcf"
+DOL_LCF_TEMPLATE = f"{CONFIG}/dol.lcf"
+DOL_LCF = f"{BUILDDIR}/dol.lcf"
 
 # Outputs
 DOL_ELF = f"{BUILDDIR}/main.elf"

--- a/config/disasm_overrides.yml
+++ b/config/disasm_overrides.yml
@@ -1,0 +1,1 @@
+trim_ctors: true

--- a/config/dol.lcf
+++ b/config/dol.lcf
@@ -37,6 +37,11 @@ SECTIONS
 	_eti_init_info = 8000569c;
 }
 
+FORCEFILES
+{
+	PPCDIS_FORCEFILES
+}
+
 __dummy_str = 0;
 __dummy_float = 0;
 __dummy_double = 0;

--- a/config/dol.yml
+++ b/config/dol.yml
@@ -12,7 +12,9 @@ section_defs:
         extabindex_:
             attr: a
         .ctors:
+            balign: 0
         .dtors:
+            balign: 0
         .BINARY:
             attr: wa
         .rodata:

--- a/config/dol_slices.yml
+++ b/config/dol_slices.yml
@@ -12,9 +12,8 @@ JSystem/JMath/random.cpp:
 JSystem/JSupport/JSUList.cpp:
     .text: [0x80078b2c, 0x800790d0]
 
-#Dolphin/__ppc_eabi_init.s:
-    #.text: [0x800f31d8, 0x800f322c]
-    #.ctors: [0x803160a0, 0x803160a4]    
+Dolphin/__ppc_eabi_init.s:
+    .text: [0x800f31d8, 0x800f322c]
 
 #JSystem/JMath/JMATrigonometric.cpp:
     #.text: [0x800693d0, 0x800697f8]
@@ -46,13 +45,13 @@ Kaneshige/RaceTime.cpp:
 Osako/main.cpp:
     .text: [0x801f75f4, 0x801f7618]
 
-#Osako/systemData.cpp:
-    #.text: [0x80205c2c, 0x80205db4]
-    #.ctors: [0x80316394, 0x80316398]
-    #.rodata: [0x8037d938, 0x8037da88]
-    #.data: [0x8039cd28, 0x8039cde8]
-    #.sbss: [0x80416a00, 0x80416a10]
-    #.sdata2: [0x8041b758, 0x8041b778]
+Osako/systemData.cpp:
+    .text: [0x80205c2c, 0x80205db4]
+    .ctors: [0x80316394, 0x80316398]
+    .rodata: [0x8037d938, 0x8037da88]
+    .data: [0x8039cd28, 0x8039cde8]
+    .sbss: [0x80416a00, 0x80416a10]
+    .sdata2: [0x8041b758, 0x8041b778]
 
 #Osako/SaveFile.cpp:
     #.text: [0x8020c230, 0x8020c3ac]

--- a/src/Dolphin/__ppc_eabi_init.s
+++ b/src/Dolphin/__ppc_eabi_init.s
@@ -1,7 +1,6 @@
 # This file is needed to fix __sinit functions unless i start decomping this. problem: Dolphin.a reguires GC MW 1.2.5 instead of 2.5 which the game uses
 
 .include "macros.inc"
-.set __init_cpp_exceptions_reference, _ctors
 
 .global __init_cpp
 __init_cpp:
@@ -9,8 +8,8 @@ __init_cpp:
 /* 800F31DC 90010004 */ stw         r0, 4(r1)
 /* 800F31E0 9421FFF0 */ stwu        r1, -0x10(r1)
 /* 800F31E4 93E1000C */ stw         r31, 0xc(r1)
-/* 800F31E8 3C608031 */ lis         r3, __init_cpp_exceptions_reference@ha
-/* 800F31EC 380360A0 */ addi        r0, r3, __init_cpp_exceptions_reference@l
+/* 800F31E8 3C608031 */ lis         r3, _ctors@ha
+/* 800F31EC 380360A0 */ addi        r0, r3, _ctors@l
 /* 800F31F0 7C1F0378 */ mr          r31, r0
 /* 800F31F4 48000004 */ b           lbl_800f31f8
 lbl_800f31f8:

--- a/src/Osako/systemData.cpp
+++ b/src/Osako/systemData.cpp
@@ -93,7 +93,7 @@ const _GXRenderModeObj SystemData::scNtscProg448Soft = {
     16, // (MAX_NTSC_HEIGTH - SCREEN_HEIGHT) / 2 0
     666,
     SCREEN_HEIGHT,
-    1,
+    0,
     0,
     0,
     {{6, 6},
@@ -121,7 +121,7 @@ const _GXRenderModeObj SystemData::scNtscProg448 = {
     16, // (MAX_NTSC_HEIGTH - SCREEN_HEIGHT) / 2 0
     666,
     SCREEN_HEIGHT,
-    1,
+    0,
     0,
     0,
     {{6, 6},


### PR DESCRIPTION
Uses ppcdis to add all generated .ctors asm files to FORCEFILES, allowing SystemData.cpp to be linked
Also fixes some mistakes in the rodata of SystemData.cpp