### PR TITLE
KartCtrlInfo - Decomp Part Two

### DIFF
--- a/include/Yamamoto/kartBody.h
+++ b/include/Yamamoto/kartBody.h
@@ -91,7 +91,7 @@ public:
 
     KartLoader *mKartLoader;
     KartSus *mKartSus[4];
-    void *mBodyModel;
+    ExModel *mBodyModel;
     DriverModel *mDriverModels[2];
     ExModel *mExModels[2];
     KartShadowModel *mShadowModel;

--- a/include/Yamamoto/kartCamera.h
+++ b/include/Yamamoto/kartCamera.h
@@ -44,8 +44,8 @@ public:
     // void InitLandView();
 
     // MJB - These inlines used by KartCtrlInfo.
-    inline f32 GetClipperScale() { return mClipper.mClipperScale; }
-    inline f32 GetLodLen(){ return _198; }
+    inline f32 GetClipperScale() { return mClipperScale; }
+    inline f32 GetLodLen(){ return mLodLen; }
 
     void SetTargetNum(u8);
     void SetClipper();
@@ -202,8 +202,8 @@ public:
     f32 _18c;                         //
     f32 _190;                         //
     f32 _194;                         //
-    f32 _198;                         //
-    f32 _19c;                         //
+    f32 mLodLen;                      // 198
+    f32 mClipperScale;                // 19c
     f32 _1a0;                         //
     f32 _1a4;                         //
     f32 _1a8;                         //

--- a/include/Yamamoto/kartCtrl.h
+++ b/include/Yamamoto/kartCtrl.h
@@ -50,7 +50,7 @@ public:
     f32 GetItemStickX(int);
     u32 GetItemButton(int);
     void DoLod();
-    void GetPortPtr(int);
+    int GetPortPtr(int);
     void GetCamFovy(int);
     void GetCamAspect(int);
     // TODO: do these return references or pointers?

--- a/include/Yamamoto/kartCtrl.h
+++ b/include/Yamamoto/kartCtrl.h
@@ -63,7 +63,7 @@ public:
     bool GetRightFTirePos(int, Vec *);
     void GetLeftTirePos(int, Vec *);
     void GetRightTirePos(int, Vec *);
-    void GetTirePos(int, int, Vec *);
+    int GetTirePos(int, int, Vec *);
     f32 GeTireG(int);
     f32 GetCarSpeed(int);
     f32 GetCarRpm(int);

--- a/include/Yamamoto/kartParams.h
+++ b/include/Yamamoto/kartParams.h
@@ -112,7 +112,7 @@ extern BodyOp *BodyOpData[21];
 // extern UNK floorThunderDepth;
 // extern UNK bridgeDepth;
 // extern UNK bridgeThunderDepth;
-// extern UNK tireOffsetPos;
+extern f32 tireOffsetPos[21];
 
 // Other Params
 

--- a/src/Yamamoto/kartCamera.cpp
+++ b/src/Yamamoto/kartCamera.cpp
@@ -259,8 +259,8 @@ void KartCam::DoPort(int camNo)
     JUT_MINMAX_ASSERT(0, mPtr, 9);
 
     SetFovyData();
-    _198 = viewdata[mPtr]._18;
-    _19c = viewdata[mPtr]._1c;
+    mLodLen = viewdata[mPtr]._18;
+    mClipperScale = viewdata[mPtr]._1c;
     _17c = viewdata[mPtr]._20;
     _180 = viewdata[mPtr]._24;
     SetClipper();

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -880,7 +880,7 @@ void KartStrat::DoSterr() {
         steeringInput = (kartGamePad->getMainStickX() + steeringInput) * 0.5f;
         
         if (steeringInput < 0.65f) {
-            steeringInput *= 1.15f;
+            steeringInput *= 0.05f;
         } else if (steeringInput >= 1.4f) {
             steeringInput *= 1.35f;
         } else if (steeringInput >= 1.3f) {

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -124,6 +124,62 @@ u32 KartCtrl::GetItemButton(int kartIndex) {
 void KartCtrl::DoLod() {
     // void KartCam::GetClipperScale() {}
     // void KartCam::GetLodLen() {}
+    u32 kartNumber = GetKartCtrl()->GetKartNumber();
+    RaceMgr *raceMgr = RaceMgr::getCurrentManager();
+    JGeometry::TVec3f kartDistToCamera; // Couldn't find a way to make this a non-C style declaration without borking things...
+
+    for (u16 j = 0; j < raceMgr->getCameraNumber(); j++) {
+        KartCam *kartCam = getKartCam(j);
+        kartCam->SetVictoryScreenPort((u8)j);
+        for (s32 i = 0, cameraNumber = 0; i < (s32)kartNumber; i++, cameraNumber += 4) {
+            KartBody *kartBody = getKartBody(i);
+            KartDrawer *kartDrawer = RaceMgr::getManager()->getKartDrawer(i);
+            raceMgr->getKartInfo(i)->getKartID();
+
+            if (getKartBody(i)->getChecker()->CheckIndication() != 0) {
+                f32 clipperScale = kartCam->GetLodLen();
+                if (kartCam->GetCameraMode() == 2) {
+                    clipperScale = 18000.0f;
+                }
+
+                kartDistToCamera.sub(kartBody->mPos, *kartCam->GetCameraPos());
+                if (kartDistToCamera.x > clipperScale || kartDistToCamera.x < -clipperScale) {
+                    kartDrawer->setLODLevel(j, 1);
+                } else if (kartCam->mClipper.mLeftPlane.x > clipperScale || kartCam->mClipper.mLeftPlane.x < -clipperScale) {
+                    kartDrawer->setLODLevel(j, 1);
+                } else if (kartCam->mClipper.mLeftPlane.y > clipperScale || kartCam->mClipper.mLeftPlane.y < -clipperScale) {
+                    kartDrawer->setLODLevel(j, 1);
+                } else {
+                    kartDrawer->setLODLevel(j, 0);
+                }
+
+                clipperScale = kartCam->GetClipperScale();
+                kartBody->mBodyModel->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+
+                clipperScale = 0.85f * kartCam->GetClipperScale();
+                kartBody->mExModels[0]->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                kartBody->mExModels[1]->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+
+                getKartSus(cameraNumber + 0)->mWheel->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                getKartSus(cameraNumber + 1)->mWheel->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                getKartSus(cameraNumber + 2)->mWheel->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                getKartSus(cameraNumber + 3)->mWheel->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+
+                if ((kartBody->mGameStatus & 0x1000) != 0) {
+                    getKartSus(cameraNumber + 0)->mShock->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                    getKartSus(cameraNumber + 1)->mShock->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                    getKartSus(cameraNumber + 2)->mShock->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                    getKartSus(cameraNumber + 3)->mShock->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+
+                    getKartSus(cameraNumber + 0)->mArm->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                    getKartSus(cameraNumber + 1)->mArm->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                    getKartSus(cameraNumber + 2)->mArm->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                    getKartSus(cameraNumber + 3)->mArm->clipBySphere(j, kartCam->GetClipper(), kartCam->GetMtx(), clipperScale);
+                }
+            }
+        }
+    }
+    return;
 }
 
 void KartCtrl::GetPortPtr(int) {}

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -222,7 +222,7 @@ int KartCtrl::GetPortPtr(int portNumber) {
     }
 
     // FIX: This return type is probably incorrect.
-    return (int)&viewdata + (offset & 0xff) * 0x28;
+    return (int)&viewdata[offset];
 }
 
 void KartCtrl::GetCamFovy(int camIndex) {

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -290,7 +290,9 @@ int KartCtrl::GetCameraNum(int kartIndex) {
     return getKartBody(kartIndex)->mCameraNum;
 }
 
-bool KartCtrl::CheckItem(int) {}
+bool KartCtrl::CheckItem(const int kartIndex) {
+    return u8((getKartBody(kartIndex)->mCarStatus & 0x80000000) != 0);
+}
 
 f32 KartCtrl::GetMaxSpeed(int kartIndex) {
     f32 maxSpeed;

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -696,11 +696,9 @@ bool KartCtrl::CheckReverse(int kartIndex) {
 
 f32 KartCtrl::GetKartScale(int kartIndex) {
     KartBody *kartBody = getKartBody(kartIndex);
-      
-    if ((kartBody->getThunder()->mFlags & 1) != 0) {
-        return kartBody->getThunder()->mScale;
-    }
-    return 1.0f;
+    return (kartBody->getThunder()->mFlags & 1) != 0
+        ? kartBody->getThunder()->mScale    // You've been... THUNDERSTRUCK!
+        : 1.0f;
 }
 
 RivalKart *KartCtrl::getKartEnemy(int kartIndex) {

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -296,7 +296,35 @@ u32 KartCtrl::GetGameStatus(int idx) {
     return getKartBody(idx)->mGameStatus;
 }
 
-void KartCtrl::SetTireDispRound(KartBody *, KartSus *, f32) {}
+void KartCtrl::SetTireDispRound(KartBody *kartBody, KartSus *kartSus, f32 reverse) {
+    f32 tireDisp = 0.02f * kartSus->_110;
+    f32 speed = 2.16f * kartBody->mSpeed;
+
+    if (kartBody->_458 < 1.0f) {
+        speed = 0.0f;
+        tireDisp = 0.0f;
+    }
+
+    if (reverse < 0.0f) {
+        speed = -speed;
+    }
+
+    tireDisp += 0.02f * speed;
+
+    if (kartBody->mGameStatus & 0x200) {
+        tireDisp = 0.0f;
+    } else if (tireDisp > 0.436111f) {
+        tireDisp = 0.436111f;
+    } else if (tireDisp < -0.436111f) {
+        tireDisp = -0.436111f;
+    }
+
+    kartSus->_10c += tireDisp;
+    if (kartSus->_10c > 3.14 || kartSus->_10c < -3.14) {
+        kartSus->_10c = 0.0f;
+    }
+    return;
+}
 
 void KartCtrl::SetKartRpm(KartBody *kartBody, f32 unknownRPM1, f32 unknownRPM2) {
     f32 unknownMultiplier = kartBody->_458 / 60.0f;

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -182,7 +182,48 @@ void KartCtrl::DoLod() {
     return;
 }
 
-void KartCtrl::GetPortPtr(int) {}
+int KartCtrl::GetPortPtr(int portNumber) {
+    u8 offset;
+    switch (RaceMgr::getCurrentManager()->getCameraNumber()) {
+        case 1:
+            offset = 0;
+            break;
+
+        case 2:
+            if (RaceMgr::getCurrentManager()->isSubScrExist()) {
+                switch (portNumber) {
+                    case 0: offset = 0; break;
+                    case 1: offset = 7; break;
+                    default: break;
+                }
+            } else {
+                switch (portNumber) {
+                    case 0: offset = 1; break;
+                    case 1: offset = 2; break;
+                    default: break;
+                }
+            }
+            break;
+
+        case 3:
+        case 4:
+            switch (portNumber) {
+                case 0: offset = 3; break;
+                case 1: offset = 4; break;
+                case 2: offset = 5; break;
+                case 3: offset = 6; break;
+                default: break;
+            }
+            break;
+
+        default:
+            offset = 0;
+            break;
+    }
+
+    // FIX: This return type is probably incorrect.
+    return (int)&viewdata + (offset & 0xff) * 0x28;
+}
 
 void KartCtrl::GetCamFovy(int camIndex) {
     getKartCam(camIndex)->GetFovy();

--- a/src/Yamamoto/kartCtrlInfo.cpp
+++ b/src/Yamamoto/kartCtrlInfo.cpp
@@ -8,6 +8,7 @@
 #include "Yamamoto/kartCtrl.h"
 
 #include "Jsystem/JAudio/JASFakeMatch2.h"
+#include "Yamamoto/kartParams.h"
 #include "kartEnums.h"
 
 // comments inside functions are inline functions being called in that function
@@ -282,7 +283,20 @@ void KartCtrl::GetRightTirePos(int kartIndex, Vec *vec) {
     GetTirePos(kartIndex, 2, vec);
 }
 
-void KartCtrl::GetTirePos(int, int, Vec *) {}
+int KartCtrl::GetTirePos(int kartIndex, int kartTireIndex, Vec *kartTireVect) {
+    KartBody* kartBody = getKartBody(kartIndex);
+    RaceMgr::getCurrentManager();
+    
+    u32 idx = kartBody->mIdx;
+    u32 kartOffset = kartTireIndex;
+    
+    kartTireVect->x = (kartBody->mKartSus[kartOffset]->mWheel->getBaseTRMtx()[0][3] - kartBody->_2fc.x * kartBody->mKartSus[kartOffset]->mTireRadius);
+    kartTireVect->y = (kartBody->mKartSus[kartOffset]->mWheel->getBaseTRMtx()[1][3] - kartBody->_2fc.y * kartBody->mKartSus[kartOffset]->mTireRadius) 
+        + tireOffsetPos[idx];
+    kartTireVect->z = (kartBody->mKartSus[kartOffset]->mWheel->getBaseTRMtx()[2][3] - kartBody->_2fc.z * kartBody->mKartSus[kartOffset]->mTireRadius);
+    
+    return (u8)(kartBody->mKartSus[kartOffset]->_124 & 1);
+}
 
 f32 KartCtrl::GeTireG(int kartIndex) {
     return getKartBody(kartIndex)->mTireG.x;


### PR DESCRIPTION
This PR contains the remaining functions to be decompiled in `KartCtrlInfo.cpp`.

The majority of functions in `KartCtrlInfo` are now 100% decompiled! 🥳 

The functions that are under 100% have the following issues: 
1. Use the incorrect registers (e.g. `r5` instead of `r3`) according to the original assembly code. I've tried re-ordering code, changing syntax etc., all with little success...
2. Have instructions that are out of order. 
Example: `KartStrat::DoSterr` at line `0x258` should be `fmuls f31, f1, f0`, but it currently has `fmuls f31, f0, f1` - **f0** and **f1** are switched, and I can't work out how to get them in the right order.
3. Reference the wrong address in .sdata2. 
Example: `KartCtrl::GetKartScale` at line 0x38: `1.0f@sda21` should be located at **name:** `@3311` **address:** `0x14` in ObjDiff, but the current code has **name:** `@1539` **address:** `0x1c`.

I'm still new to decompiling, so I'm not sure how to fix the above issues. That being said, if anyone can give me some tips, or wants to jump in themselves, please be my guest. 😄 