### PR TITLE
Jugem

### DIFF
--- a/include/JSystem/JGeometry/Matrix.h
+++ b/include/JSystem/JGeometry/Matrix.h
@@ -94,17 +94,48 @@ namespace JGeometry {
             rDest.set(this->at(0,1), this->at(1, 1), this->at(2, 1));
         }
 
-        inline void getZDir(TVec3f &rDest) const {
+        inline void getZDir(TVec3f &rDest) const
+        {
             rDest.set(this->at(0, 2), this->at(1, 2), this->at(2, 2));
-        }
+        };
 
-        void getXYZDir(TVec3f &rDestX, TVec3f &rDestY, TVec3f &rDestZ) const;
-        void setXDir(const TVec3f &rSrc);
-        void setXDir(f32 x, f32 y, f32 z);
-        void setYDir(const TVec3f &rSrc);
-        void setYDir(f32 x, f32 y, f32 z);
-        void setZDir(const TVec3f &rSrc);
-        void setZDir(f32 x, f32 y, f32 z);
+        // From SMG
+        void setXDir(const TVec3f &param_1)
+        {
+            this->ref(0, 0) = param_1.x;
+            this->ref(1, 0) = param_1.y;
+            this->ref(2, 0) = param_1.z;
+        }
+        void setXDir(f32 x, f32 y, f32 z)
+        {
+            this->ref(0, 0) = x;
+            this->ref(1, 0) = y;
+            this->ref(2, 0) = z;
+        }
+        void setYDir(const TVec3f &param_1)
+        {
+            this->ref(0, 1) = param_1.x;
+            this->ref(1, 1) = param_1.y;
+            this->ref(2, 1) = param_1.z;
+        }
+        void setYDir(f32 x, f32 y, f32 z)
+        {
+            this->ref(0, 1) = x;
+            this->ref(1, 1) = y;
+            this->ref(2, 1) = z;
+        }
+        void setZDir(const TVec3f &param_1)
+        {
+            this->ref(0, 2) = param_1.x;
+            this->ref(1, 2) = param_1.y;
+            this->ref(2, 2) = param_1.z;
+        }
+        void setZDir(f32 x, f32 y, f32 z)
+        {
+            this->ref(0, 2) = x;
+            this->ref(1, 2) = y;
+            this->ref(2, 2) = z;
+        }
         void setXYZDir(const TVec3f &rSrcX, const TVec3f &rSrcY, const TVec3f &rSrcZ)
         {
             this->ref(0, 0) = rSrcX.x;
@@ -204,7 +235,57 @@ namespace JGeometry {
             }
         }
 
-        void setQuat(const TQuat4f &rSrc);
+        void setQuat(const TQuat4f &q) {
+            f32 yy = 2.0f * q.y * q.y;
+            f32 zz = 2.0f * q.z * q.z;
+            f32 xx = 2.0f * q.x * q.x;
+
+            f32 xy = 2.0f * q.x * q.y;
+            f32 xz = 2.0f * q.x * q.z;
+            f32 yz = 2.0f * q.y * q.z;
+
+            f32 wx = 2.0f * q.w * q.x;
+            f32 wy = 2.0f * q.w * q.y;
+            f32 wz = 2.0f * q.w * q.z;
+
+            this->mMtx[0][0] = 1.0f - yy - zz;
+            this->mMtx[0][1] = xy - wz;
+            this->mMtx[0][2] = xz + wy;
+
+            this->mMtx[1][0] = xy + wz;
+            this->mMtx[1][1] = 1.0f - xx - zz;
+            this->mMtx[1][2] = yz - wx;
+
+            this->mMtx[2][0] = xz - wy;
+            this->mMtx[2][1] = yz + wx;
+            this->mMtx[2][2] = 1.0f - xx - yy;
+        }
+
+        void makeMtx(MtxPtr pMtx) const {
+            f32 yy = 2.0f * this->y * this->y;
+            f32 zz = 2.0f * this->z * this->z;
+            f32 xx = 2.0f * this->x * this->x;
+
+            f32 xy = 2.0f * this->x * this->y;
+            f32 xz = 2.0f * this->x * this->z;
+            f32 yz = 2.0f * this->y * this->z;
+
+            f32 wx = 2.0f * this->w * this->x;
+            f32 wy = 2.0f * this->w * this->y;
+            f32 wz = 2.0f * this->w * this->z;
+
+            pMtx[0][0] = 1.0f - yy - zz;
+            pMtx[0][1] = xy - wz;
+            pMtx[0][2] = xz + wy;
+
+            pMtx[1][0] = xy + wz;
+            pMtx[1][1] = 1.0f - xx - zz;
+            pMtx[1][2] = yz - wx;
+
+            pMtx[2][0] = xz - wy;
+            pMtx[2][1] = yz + wx;
+            pMtx[2][2] = 1.0f - xx - yy;
+        }
 
         void getScale(TVec3f &rDest) const;
         void setScale(const TVec3f &rSrc);
@@ -214,6 +295,27 @@ namespace JGeometry {
 
         void mult33(TVec3f &) const;
         void mult33(const TVec3f &, TVec3f &) const;
+
+        inline void getXDirInline(TVec3f &rDest) const {
+            f32 z = this->mMtx[2][0];
+            f32 y = this->mMtx[1][0];
+            f32 x = this->mMtx[0][0];
+            rDest.set(x, y, z);
+        }
+
+        inline void getYDirInline(TVec3f &rDest) const {
+            f32 z = this->mMtx[2][1];
+            f32 y = this->mMtx[1][1];
+            f32 x = this->mMtx[0][1];
+            rDest.set(x, y, z);
+        }
+
+        inline void getZDirInline(TVec3f &rDest) const {
+            f32 z = this->mMtx[2][2];
+            f32 y = this->mMtx[1][2];
+            f32 x = this->mMtx[0][2];
+            rDest.set(x, y, z);
+        }
 
 #ifdef NON_MATCHING
         inline void mult33Inline(const TVec3f &rSrc, TVec3f &rDest) const
@@ -236,9 +338,14 @@ namespace JGeometry {
         void getTrans(TVec3f &rDest) const {
             rDest.set(this->at(0, 3), this->at(1, 3), this->at(2, 3));
         }
-
-        void setTrans(const TVec3f &rSrc);
-        void setTrans(f32 x, f32 y, f32 z);
+        void setTrans(const TVec3<f32>& translation) {
+            setTrans(translation.x, translation.y, translation.z);
+        }
+        void setTrans(f32 x, f32 y, f32 z) {
+            this->ref(0, 3) = x;
+            this->ref(1, 3) = y;
+            this->ref(2, 3) = z;
+        }
         void zeroTrans()
         {
             this->ref(0, 3) = 0.0f;
@@ -269,7 +376,15 @@ namespace JGeometry {
             this->ref(1, 3) = (rLookAt[0][3] * this->mMtx[1][0]) - (rLookAt[1][3] * this->mMtx[1][1]) + rLookAt[2][3] * this->mMtx[1][2];
             this->ref(2, 3) = (rLookAt[0][3] * this->mMtx[2][0]) - (rLookAt[1][3] * this->mMtx[2][1]) + rLookAt[0][3] * this->mMtx[2][2];
         }
+
         void setQT(const TQuat4f &rSrcQuat, const TVec3f &rSrcTrans);
+
+        inline void getTransInline(TVec3f &rDest) const {
+            f32 z = this->mMtx[2][3];
+            f32 y = this->mMtx[1][3];
+            f32 x = this->mMtx[0][3];
+            rDest.set(x, y, z);
+        }
     };
 
     typedef TMatrix34<TSMtxf> TMtx34f;

--- a/include/JSystem/JGeometry/Quat.h
+++ b/include/JSystem/JGeometry/Quat.h
@@ -53,6 +53,16 @@ namespace JGeometry {
     class TQuat4<f32> : public Quaternion {
     public:
         JGeometry::TVec3f& xyz() { return (JGeometry::TVec3f&)*this; }
+
+        TQuat4() {}
+        TQuat4(f32 _x, f32 _y, f32 _z, f32 _w)
+        {
+            this->x = _x;
+            this->y = _y;
+            this->z = _z;
+            this->w = _w;
+        }
+        
         template <typename A>
         void set(A _x, A _y, A _z, A _w) {
             x = _x;

--- a/include/JSystem/JGeometry/Quat.h
+++ b/include/JSystem/JGeometry/Quat.h
@@ -14,6 +14,23 @@ namespace JGeometry {
         /* Constructors */
         inline TQuat4() {}
 
+        TQuat4(T xyz, T _w)
+        {
+            this->x = xyz;
+            this->y = xyz;
+            this->z = xyz;
+            this->w = _w;
+        }
+
+        TQuat4(T _x, T _y, T _z, T _w)
+        {
+            this->x = _x;
+            this->y = _y;
+            this->z = _z;
+            this->w = _w;
+        }
+
+
         template <typename A>
         TQuat4(A _x, A _y, A _z, A _w)
         {
@@ -35,6 +52,7 @@ namespace JGeometry {
     template <>
     class TQuat4<f32> : public Quaternion {
     public:
+        JGeometry::TVec3f& xyz() { return (JGeometry::TVec3f&)*this; }
         template <typename A>
         void set(A _x, A _y, A _z, A _w) {
             x = _x;
@@ -91,10 +109,70 @@ namespace JGeometry {
         void setEuler(f32 _x, f32 _y, f32 _z);
         void setEulerZ(f32 _z);
 
-        void setRotate(const TVec3f &, const TVec3f &, f32);
-        void setRotate(const TVec3f &, const TVec3f &);
-        void setRotate(const TVec3f &, f32);
-        void rotate(TVec3f &rDest) const;
+        // void setRotate(const TVec3f &, const TVec3f &, f32);
+        // void setRotate(const TVec3f &, const TVec3f &);
+        // void setRotate(const TVec3f &, f32);
+        // void rotate(TVec3f &rDest) const;
+
+        void setRotate(const TVec3f& pVec, f32 pAngle)
+        {
+            this->xyz().scale(sinf(pAngle * 0.5f), pVec);
+            this->w = cosf(pAngle * 0.5f);
+        }
+
+        void setRotate(const TVec3f& from, const TVec3f& to, f32 amount)
+        {
+            TVec3<T> axis;
+            axis.cross(from, to);
+
+            f32 len = axis.length();
+            if (len <= JGeometry::TUtilf::epsilon()) {
+                this->set(0.0f, 0.0f, 0.0f, 1.0f);
+                return;
+            }
+
+            f32 halfAngle = 0.5f * atan2f(len, from.dot(to)) * amount;
+            this->xyz().scale(sin(halfAngle) / len, axis);
+            this->w = cos(halfAngle);
+        }
+
+        void setRotate(const TVec3f& a, const TVec3f& b)
+        {
+            setRotate(a, b, 1.0f);
+        }
+
+        // Assumes unit quaternion. These were renamed to "transform" in SMG.
+        void rotate(const TVec3f& v, TVec3f& rDest) const
+        {
+            // Incollect regalloc
+            f32 vx = v.x;
+            f32 vy = v.y;
+            f32 vz = v.z;
+
+            T w = this->w;
+            T z = this->z;
+            T y = this->y;
+            T x = this->x;
+
+            // clang-format off
+            JGeometry::TQuat4f q;
+            q.x =  w *  0 + y * vz - z * vy + w * vx;
+            q.y = -x * vz + y *  0 + z * vx + w * vy;
+            q.z =  x * vy - y * vx + z *  0 + w * vz;
+            q.w = -x * vx - y * vy - z * vz + w *  0;
+
+            JGeometry::TQuat4f q2;
+            q2.x =  q.x *  w + q.y * -z - q.z * -y + q.w * -x;
+            q2.y = -q.x * -z + q.y *  w + q.z * -x + q.w * -y;
+            q2.z =  q.x * -y - q.y * -x + q.z *  w + q.w * -z;
+            // clang-format on
+
+            // This set wasn't inlined in SMG, so should be real?
+            rDest.set(q2.x, q2.y, q2.z);
+        }
+
+        void rotate(TVec3f& rDest) const { rotate(rDest, rDest); }
+
 
         void slerp(const TQuat4 &a1, const TQuat4 &a2, f32 a3) {
             this->x = a1.x;
@@ -143,8 +221,29 @@ namespace JGeometry {
             this->w = s0 * q1.w + s1 * q2.w;
         }
 
-        void transform(const TVec3f &, TVec3f &rDest);
-        void transform(TVec3f &rDest);
+        void transform(const JGeometry::TVec3f& v, JGeometry::TVec3f& rDest) const {
+            // transformation via hamiltonian multiplication of a unit quaternion
+            // q*v*q`
+            // where v is the input vector converted into a quaternion with w=0
+            // and q` is the multiplicative inverse of q
+            // (eg: q = w + xi + yj + zk, q` = w - xi - yj - zk)
+
+            TQuat4 r;
+            r.x = ( this->y * v.z) - (this->z * v.y) + (this->w * v.x);
+            r.y = (-this->x * v.z) + (this->z * v.x) + (this->w * v.y);
+            r.z = ( this->x * v.y) - (this->y * v.x) + (this->w * v.z);
+            r.w = (-this->x * v.x) - (this->y * v.y) - (this->z * v.z);
+
+            rDest.template set<T>(
+                 r.x *  this->w + r.y * -this->z - r.z * -this->y + r.w * -this->x,
+                -r.x * -this->z + r.y *  this->w + r.z * -this->x + r.w * -this->y,
+                 r.x * -this->y - r.y * -this->x + r.z *  this->w + r.w * -this->z
+            );
+        }
+
+        void transform(JGeometry::TVec3f& v) const {
+            transform(v, v);
+        }
 
         bool equals(const TQuat4 &other) 
         {

--- a/include/Kaneshige/ExModel.h
+++ b/include/Kaneshige/ExModel.h
@@ -56,7 +56,7 @@ public:
     virtual void setCurrentViewNo(u32);                               // 0x801a5614
 
     // Inlines
-    const Mtx &getBaseTRMtx() { return mBaseTRMtx.mMtx; }
+    const Mtx &getBaseTRMtx() { return mBaseTRMtx; }
     void hide(u32 p1) { clipAll(p1, false); }
     void show(u32 p1) { clipAll(p1, true); }
     bool isAllShapePacketHidding(u32 viewNo) { return isAllShapePacketHidding(0, viewNo); }
@@ -97,7 +97,7 @@ public:
     u16 _1a;                      // 1A
     u16 mSimpleTevReg;            // 1C
     JGeometry::TVec3f mScale;     // 20
-    JGeometry::TPos3f mBaseTRMtx; // 2C
+    Mtx mBaseTRMtx;               // 2C
     Mtx _5c;                      // 5C
 }; // Size: 0x8c
 

--- a/include/Kaneshige/ExModel.h
+++ b/include/Kaneshige/ExModel.h
@@ -56,7 +56,7 @@ public:
     virtual void setCurrentViewNo(u32);                               // 0x801a5614
 
     // Inlines
-    const Mtx &getBaseTRMtx() { return mBaseTRMtx; }
+    const Mtx &getBaseTRMtx() { return mBaseTRMtx.mMtx; }
     void hide(u32 p1) { clipAll(p1, false); }
     void show(u32 p1) { clipAll(p1, true); }
     bool isAllShapePacketHidding(u32 viewNo) { return isAllShapePacketHidding(0, viewNo); }
@@ -88,17 +88,17 @@ public:
 
 public:
     // Vtable 0x0
-    u16 mLevelCnt;             // 04
-    J3DModelData **mModelData; // 08
-    J3DModel **mModel;         // 0C
-    u32 mMagic;                // 10
-    int _14;                   // 
-    u16 _18;                   // 
-    u16 _1a;                   //
-    u16 mSimpleTevReg;         // 1C
-    JGeometry::TVec3f mScale;  // 20
-    Mtx mBaseTRMtx;            // 2C
-    Mtx _5c;                   // 5C
+    u16 mLevelCnt;                // 04
+    J3DModelData **mModelData;    // 08
+    J3DModel **mModel;            // 0C
+    u32 mMagic;                   // 10
+    u32 *_14;                     // 14 - Some void ptr equivalent?
+    u16 _18;                      // 18
+    u16 _1a;                      // 1A
+    u16 mSimpleTevReg;            // 1C
+    JGeometry::TVec3f mScale;     // 20
+    JGeometry::TPos3f mBaseTRMtx; // 2C
+    Mtx _5c;                      // 5C
 }; // Size: 0x8c
 
 class ExMDRecord {

--- a/include/Kaneshige/KartChecker.h
+++ b/include/Kaneshige/KartChecker.h
@@ -153,6 +153,8 @@ public:
             mLap++;
     }
 
+    int getLap() { return mLap; }
+
     bool incBalloon();
     bool decBalloon();
 

--- a/include/Kaneshige/KartDrawer.h
+++ b/include/Kaneshige/KartDrawer.h
@@ -92,6 +92,7 @@ public:
     }
 
     RaceKartLight *getLight(u32 viewNo) {
+#line 112
         JUT_MAX_ASSERT(viewNo, 4);
         return mKartLight[viewNo];
     }

--- a/include/Kaneshige/MdlViewer.h
+++ b/include/Kaneshige/MdlViewer.h
@@ -131,6 +131,8 @@ public:
     void appendHio(HioNode *);
     // Inline
     MVCamera *getCamera() { return mCamera; }
+    MVChaseLight *getChaseLight() { return mChaseLight; }
+    
 private:
     int _0; //
     MVCamera *mCamera; // 04

--- a/include/Kaneshige/Movie/MovieApp.h
+++ b/include/Kaneshige/Movie/MovieApp.h
@@ -48,6 +48,9 @@ public:
 
     static MovieApp *getMovieApp() { return sMovieApp; }
 
+    // Inline
+    MdlViewer *getMdlViewer() { return mMdlViewer; }
+
 private:
     static MovieApp *sMovieApp; // 0x80416840
     static void *mspHeapBuffer; // 0x80416844

--- a/include/Kaneshige/RaceDrawer.h
+++ b/include/Kaneshige/RaceDrawer.h
@@ -52,6 +52,8 @@ public:
     void setBlurDecrease(u8 a) { mBlurDecrease = a; }
     void setBlurColor(const JUTColor &color) { mBlurColor.set(color);  }
 
+    u8 getKartNum() { return mKartNum; }
+
     DrawBuffer *getItemDrawBuffer(int kartNo) {
 #line 163
         JUT_MINMAX_ASSERT(-1, kartNo, 8)

--- a/include/Kaneshige/ViewCtrlModel.h
+++ b/include/Kaneshige/ViewCtrlModel.h
@@ -28,6 +28,7 @@ public:
     void setDetailFlg() { mFlags |= 0x10; }
     void setVisibleAll() { mFlags |= 0xf; }
     void setVisible(u32 cnsNo) { mFlags |= (1 << cnsNo);  }
+    void clearVisible(u32 cnsNo) { mFlags &= ~(1 << cnsNo);  }
     u8 getFlags() const { return mFlags; }
 
 private:

--- a/include/Kawano/driver.h
+++ b/include/Kawano/driver.h
@@ -136,6 +136,8 @@ public:
     int IsChange();
     int IsChangeBack();
     int IsChangeFront();
+    int IsSit();
+    int IsStand();
 
 public:
     u8 _8c[0xfc - 0x8c];

--- a/include/Osako/shadowModel.h
+++ b/include/Osako/shadowModel.h
@@ -26,6 +26,7 @@ public:
 
     ShadowKind getShadowKind() const { return mKind; }
     u8 getAlpha() const { return _94; }
+    void setAlpha(u8 newAlpha) { _94 = newAlpha; }
     u8 getFlag95() const { return _95; }
     void setFlag95(bool flag) { _95 = flag; }
 

--- a/include/Sato/AnmController.h
+++ b/include/Sato/AnmController.h
@@ -33,6 +33,7 @@ public:
     bool tstFlgAnmStop() const { return mFlags & 1; }
     bool tstFlgAnm2() const { return mFlags & 2; }
     void resetFlag() { mFlags &= ~1; }
+    void setFlag() { mFlags |= 1; }
 
     u8 mFlags;                     // 4
     u8 mMaxAnmNo;                  // 5

--- a/include/Sato/GeographyObj.h
+++ b/include/Sato/GeographyObj.h
@@ -14,6 +14,7 @@
 #include "Sato/ItemObj.h"
 #include "Sato/ObjCollision.h"
 #include "Sato/stMath.h"
+#include "Shiraiwa/AnmPlayer.h"
 
 // TODO: Remove Forward declarations
 class ObjColBase; // ObjCollision.h
@@ -35,6 +36,12 @@ private:
 struct GeoAnmTableEntry {
     u32 _0; // unused?
     const char *fileName;
+};
+
+// TODO: This pattern may apply elsewhere... look for better place for it to exist.
+struct TJugemAnmTableEntry {
+    TAnmInfo *tAnmInfo;
+    u8 arraySize;
 };
 
 class GeoObjSupervisor
@@ -114,9 +121,9 @@ public:
     bool IsPathMove() const { return mObjData->pathID != 0xffff; }
 
     template<class T>
-    static T *New(CrsData::SObject &object) { return new T(object); }
+    static T *New(const CrsData::SObject &object) { return new T(object); }
     template<class T>
-    static T *NewS(CrsData::SObject &object) { return new T(object); }
+    static T *NewS(const CrsData::SObject &object) { return new T(object); }
 
     void NewAnmCtrl() {
         if (mAnmCtrl == nullptr) {
@@ -266,7 +273,8 @@ public:
     u16 mIsHitKartSoundPlayedFlg;         // FA
     JSULink<GeographyObj> mObjLink;       // FC
     int mKind;                            // 10C
-    u8 _110[0x114 - 0x110];               //
+    u16 _110;                             // 110
+    u16 _112;                             // 112
     ItemObj *mColItemObj;                 // 114
     ShadowModel *mShadowMdl;              // 118
     u16 mObjFlag;                         // 11C
@@ -299,7 +307,7 @@ public:
     virtual void lockDisplayList() {}
 
     template<class T>
-    static T *ExNew(CrsData::SObject &object) { return new T(object); }
+    static T *ExNew(const CrsData::SObject &object) { return new T(object); }
 
     ExObjColBase *getExBounds() const { return mExBounds; }
 

--- a/include/Sato/J3DAnmObject.h
+++ b/include/Sato/J3DAnmObject.h
@@ -18,6 +18,7 @@ class J3DAnmObjBase
 public:
     J3DAnmObjBase() { mModel = nullptr; }
 
+    void loadJ3DModelData(void *, u32);
     void initFrameCtrl(J3DAnmBase *base);
     void frameProc() { mFrameCtrl.update(); }
     void update() { mFrameCtrl.update(); }
@@ -82,6 +83,7 @@ public:
     virtual ~J3DAnmObjMaterial() {}
     virtual void anmFrameProc() { mAnmBase->setFrame(mFrameCtrl.getFrame()); }
 
+    static void setupColorAnmData(J3DAnmColor **, J3DModelData *, void *);
     static void setupTexSRTAnmData(J3DAnmTextureSRTKey **, J3DModelData *, void *);
     static void setupTevRegAnmData(J3DAnmTevRegKey **, J3DModelData *, void *);
     static void setupTexPatternAnmData(J3DAnmTexPattern **, J3DModelData *, void *);
@@ -91,6 +93,9 @@ public:
         mAnmBase = anm;
         J3DAnmObjBase::initFrameCtrl(mAnmBase);
     }
+
+    template <typename T>
+    static void setMaterialAnmTev(T**, J3DModelData*);
 
     J3DAnmBase *getAnmBase() { return mAnmBase; }
     void setAnmBase(J3DAnmBase *base) { mAnmBase = base; }

--- a/include/Shiraiwa/AnmPlayer.h
+++ b/include/Shiraiwa/AnmPlayer.h
@@ -14,9 +14,9 @@ public:
     J3DMtxCalc *mCalcAnm;       // 8
     int mAnmCnt;                // C
     u8 mBlendFrameCnt;          // 10
-    u8 _11;                     // 
-    s8 _12;                     //
-
+    u8 _11;                     // 11
+    s8 _12;                     // 12
+    s8 _13;                     // 13
 }; // Size: 0x14
 
 class TAnmPlayer

--- a/include/Shiraiwa/Interp.h
+++ b/include/Shiraiwa/Interp.h
@@ -28,6 +28,11 @@ public:
     void reset();
     void calcPoint(f32);
     void getSamplePoint(u8, u8 *, u8 *);
+
+    inline bool checkUnknownBool13() { return _13; }
+    inline s16 getUnknownValue10() { return _10; }
+    inline f32 getRatio() { return mRatio; }
+
 protected:
     u8 _4;
     u8 _5;

--- a/include/Shiraiwa/JugemHeadItem.h
+++ b/include/Shiraiwa/JugemHeadItem.h
@@ -1,24 +1,26 @@
 #ifndef JUGEMHEADITEM_H
 #define JUGEMHEADITEM_H
 
+#include "JSystem/JGeometry/Matrix.h"
 #include "Sato/GeographyObj.h"
+#include "Sato/J3DAnmObject.h"
+#include "types.h"
 
 class TJugemHeadItem : public GeographyObj {
 public:
-    TJugemHeadItem(u32 id) : GeographyObj(id) {
-        _14c = 0;
+    TJugemHeadItem(u32 id) : GeographyObj(id), mJugemParentPtr(nullptr) {
     }
     virtual ~TJugemHeadItem() {}
     virtual void calc() {} 
-    virtual void setPosition(const JGeometry::TVec3f &pos) { mPos.set(pos); } // 80
-    virtual void setRMtx(const JGeometry::TPos3f &rMtx) { mRotMtx.set(rMtx);  } // 84
+    virtual void setPosition(const JGeometry::TVec3f &pos); // 80
+    virtual void setRMtx(const JGeometry::TPos3f &rMtx); // 84
     virtual void hideModel(u32 p1) { mModel.clipAll(p1, false); } // 88
-    virtual void show() { mGeoObjFlag &= ~0x20; } // 8c
-    virtual void hide() { mGeoObjFlag |= 0x20; } // 90
+    virtual void show(u8); // 8c
+    virtual void hide(); // 90
     virtual void hideAll() { hide(); } // 94
 
-protected:
-    int _14c;
+public:
+    int mJugemParentPtr;
 };
 
 class TJugemHeadHear : public TJugemHeadItem {
@@ -43,7 +45,9 @@ public:
 
     static J3DAnmTevRegKey *sJugemHeadLampBrkAnm; // 0x80417018
     static J3DAnmTransform *sJugemHeadLampBcaAnm; // 0x8041701c
-    static J3DMtxCalc *sJugemHeadLampBcaMtxCalc; // 0x80417020
+    static J3DMtxCalc *sJugemHeadLampBcaMtxCalc;  // 0x80417020
+
+    J3DAnmObjMaterial _150;   // 150
 };
 
 #endif // JUGEMHEADITEM_H

--- a/include/Shiraiwa/JugemItem.h
+++ b/include/Shiraiwa/JugemItem.h
@@ -1,19 +1,22 @@
 #ifndef JUGEMITEM_H
 #define JUGEMITEM_H
 
+#include "Sato/AnmController.h"
+#include "Sato/GeographyObj.h"
+#include "Shiraiwa/AnmPlayer.h"
 #include "Shiraiwa/JugemRodItem.h"
 
 class TJugemItem : public GeographyObj {
 public:
-    TJugemItem(u32 id) : GeographyObj(id) {
-        _14c = 0;
+    TJugemItem(u32 id) : GeographyObj(id), mJugemParentPtr(nullptr) {
+        setObjFlagHidding();
     }
     virtual ~TJugemItem() {}
     virtual void calc() {} 
     virtual void setPosition(const JGeometry::TVec3f &pos) { mPos.set(pos); } // 80
-    virtual void setRMtx(const JGeometry::TPos3f &rMtx) { mRotMtx.set(rMtx);  } // 84
+    virtual void setRMtx(const JGeometry::TPos3f &rMtx) { mRotMtx.set(rMtx.mMtx);  } // 84
     virtual void hideModel(u32 p1) { mModel.clipAll(p1, false); } // 88
-    virtual void show() { mGeoObjFlag &= ~0x20; } // 8c
+    virtual void show(u8) { mGeoObjFlag &= ~0x20; } // 8c
     virtual void hide() { mGeoObjFlag |= 0x20; } // 90
     virtual void hideAll() { hide(); } // 94
     virtual void hold(u32) {} // 98
@@ -26,8 +29,9 @@ public:
             mAnmCtrl->StopTrans();
     }
 
-protected:
-    int _14c;
+public:
+    int mJugemParentPtr;
+    TAnmPlayer mJugemAnmPlayer;
 };
 
 class TJugemVoidRod : public TJugemItem {
@@ -41,8 +45,8 @@ public:
     virtual void createModel(JKRSolidHeap *, u32); // 0x802918c0
     virtual void calc(); // 0x802919dc
     virtual void createColModel(J3DModelData *); // 0x80291a0c
-    virtual void setPosition(const JGeometry::TVec3f &); // 0x80291a10
-    virtual void setRMtx(const JGeometry::TPos3f &); // 0x80291a2c
+    virtual void setPosition(const JGeometry::TVec3f &pos) { mPos.set(pos); } // 0x80291a10
+    virtual void setRMtx(const JGeometry::TPos3f &rMtx) { mRotMtx.set(rMtx.mMtx); } // 0x80291a2c
     virtual void hideModel(u32); // 0x80291a60
     virtual void show(u8); // 0x80291ab4
     virtual void update(); // 0x80291b08
@@ -50,26 +54,47 @@ public:
     virtual void hideAll(); // 0x80291b9c
     virtual void hold(u32); // 0x80291cb4
     virtual void changeAnimation(u32); // 0x80291d74
-   
+    
     void setJugemRodItem(TJugemRodItem *, u32); // 0x80291c34
-    void nodeCallBack(J3DJoint *, int); // 0x80291ecc
+    static bool nodeCallBack(J3DJoint *, int); // 0x80291ecc
 
-    TJugemRodSignal *getSignal() const { return mSignal; }
+    TJugemRodSignal *getSignal() const { return (TJugemRodSignal *)_188[2]; }
 
-    //void sAnmInfos_Rod_Lap; // 0x803a3ac0
-    //void sAnmInfos_Rod_Start; // 0x803a3b10
-    //void sAnmInfos_Rod_Reverse; // 0x803a3b74
-    //void sAnmInfos_Rod_Rescue; // 0x803a3b9c
-    //void sAnmInfos_Rod_Signal; // 0x803a3bd8
-    //void sAnmInfos_Rod_PukuS; // 0x803a3c14
-    //void sAnmInfos_Rod_PukuL; // 0x803a3c50
-    //void sAnmStateTable; // 0x803a3c8c
-    //void sDemoAnmStateTable; // 0x803a3cac
-    // Inline/Unused
-    //void getPointPos(JGeometry::TVec3f *);
-    u8 _150[0x190 - 0x150];
-    TJugemRodSignal *mSignal; // 190
-    u8 _194[0x1a8 - 0x194]; //
+    static TAnmInfo sAnmInfos_Rod_Lap[4]; // 0x803a3ac0
+    static TAnmInfo sAnmInfos_Rod_Start[5]; // 0x803a3b10
+    static TAnmInfo sAnmInfos_Rod_Reverse[2]; // 0x803a3b74
+    static TAnmInfo sAnmInfos_Rod_Rescue[3]; // 0x803a3b9c
+    static TAnmInfo sAnmInfos_Rod_Signal[3]; // 0x803a3bd8
+    static TAnmInfo sAnmInfos_Rod_PukuS[3]; // 0x803a3c14
+    static TAnmInfo sAnmInfos_Rod_PukuL[3]; // 0x803a3c50
+    static TJugemAnmTableEntry sAnmStateTable[4]; // 0x803a3c8c
+    static TJugemAnmTableEntry sDemoAnmStateTable[3]; // 0x803a3cac
+
+    //  Inline/Unused
+    // void getPointPos(JGeometry::TVec3f *);
+
+    AnmController *mRodAnmController[4];
+    AnmController *mDemoRodAnmController[3];
+    TJugemRodItem *_184;
+    TJugemRodItem *_188[6];
+    u8 _1a0[0x1a4 - 0x1a0]; // What is this?
+    int _1a4;   // 1A4 - current model index?
 }; // Size: 0x1a8
+
+class TJugemFlag : public TJugemItem {
+public:
+    TJugemFlag();
+    virtual ~TJugemFlag();
+    virtual void reset();
+    virtual void loadAnimation();
+    virtual const char *getShadowBmdFileName();
+    virtual const char *getBmdFileName();
+    virtual void createModel(JKRSolidHeap *, u32);
+    virtual void createColModel(J3DModelData *);
+    virtual void changeAnimation(u32);
+
+    static J3DAnmTransform *sJugemFlagBckAnmTrans;
+    static J3DMtxCalc *sJugemFlagBckMtxCalc;
+};
 
 #endif

--- a/include/Shiraiwa/JugemMain.h
+++ b/include/Shiraiwa/JugemMain.h
@@ -1,23 +1,29 @@
 #ifndef JUGEMMAIN_H
 #define JUGEMMAIN_H
 
+#include "JSystem/JGeometry/Matrix.h"
+#include "JSystem/JGeometry/Vec.h"
+#include "JSystem/JKernel/JKRHeap.h"
+#include "Kaneshige/DarkAnmMgr.h"
+#include "Sato/AnmController.h"
+#include "Sato/GeographyObj.h"
+#include "Sato/J3DAnmObject.h"
 #include "Sato/StateObserver.h"
+#include "Shiraiwa/Interp.h"
 #include "Shiraiwa/Objects/MapObjHioNode.h"
 #include "Shiraiwa/JugemItem.h"
 #include "Shiraiwa/JugemHeadItem.h"
 #include "Shiraiwa/JugemRodItem.h"
 #include "Shiraiwa/AnmPlayer.h"
+#include "dolphin/mtx.h"
+#include "dolphin/types.h"
+
 
 class TJugem : public TMapObjHioNode, public StateObserver
 {
 public:
     TJugem();
-
-    void setJugemItem(TJugemItem *, u32);
-    void setJugemHeadItem(TJugemHeadItem *item, u32 id);
-    void setCameraNum(u8 cam);
-
-    virtual ~TJugem() {}
+    virtual ~TJugem();
     virtual void loadAnimation();
     virtual void createModel(JKRSolidHeap *, u32);
     virtual void createShadowModel(JKRSolidHeap *, u32);
@@ -27,13 +33,135 @@ public:
     virtual void viewCalc(u32);
     virtual void setCurrentViewNo(u32);
     virtual const char *getBmdFileName();
+    virtual const char *getShadowBmdFileName();
     virtual const char *getJ3DModelDataTevStageNum();
     virtual void createColModel(J3DModelData *);
 
-    virtual void MoveExec();
     virtual void InitExec();
+    virtual void MoveExec();
 
-    bool isDemoMode();
+    void resetStaticData();
+    void hold(u32, u32);
+    void setJugemItem(TJugemItem *, u32);
+    void setJugemHeadItem(TJugemHeadItem *item, u32 id);
+    
+    bool checkVisible(u32);
+    void initFunc_Erase();
+    void doFunc_Erase();
+    void initFunc_Wait();
+    void doFunc_Wait();
+    
+    void resetJugemOriginCourse();
+    void resetJugemOriginNumber();
+    
+    void getZDir(int, JGeometry::TVec3f *);
+    void resetJugemOrigin(const JGeometry::TVec3f &, const JGeometry::TVec3f &);
+    void getJugemOrigin(const JGeometry::TVec3f &, JGeometry::TVec3f *);
+    
+    void move(int);
+    bool checkKartCrash();
+    
+    void setPosition(const JGeometry::TVec3f &);
+    void setRMtx(const JGeometry::TPos3f &);
+    void resetAllPosAndMtx();
+    void localMove(JGeometry::TVec3f *);
+    void globalMove(JGeometry::TVec3f *);
+    int getGlobalState();
+    void fixPosition(JGeometry::TVec3f *, f32);
+    f32 fixGround(CrsGround &, const JGeometry::TVec3f &);
+    void fixWall(CrsGround &, JGeometry::TVec3f *);
+    void fixNear(JGeometry::TVec3f *);
+    void setLimitation(JGeometry::TVec3f *, f32, f32);
+    void chase(int, const JGeometry::TVec3f &, const JGeometry::TVec3f &, JGeometry::TVec3f &);
+    void hideAll();
+    void show(u8);
+    
+    void wearCap(u32);
+    void changeAnimation(u32);
+    void cutFishLine();
+    static bool nodeCallBack(J3DJoint *, int);
+
+    void setKartNum(u8);
+    static u32 getScreenType();
+    u32 getJ3DModelDataTevStageNum() const {
+        return 0x20020; // TODO: Identify what this value really represents.
+    }
+    
+    void setCameraNum(u8 cam);
+
+
+    // The following declarations exist across multiple files:
+    
+    // JugemRescue
+    void initFunc_RescueWait();
+    void doFunc_RescueWait();
+    void initFunc_Rescue();
+    void doFunc_Rescue();
+    bool checkRescueInProc();
+    bool checkRescueOutProc();
+
+
+    // JugemReverse
+    void initFunc_Reverse();
+    void doFunc_Reverse();
+    void initFunc_RevEnd();
+    void doFunc_RevEnd();
+    bool checkReverseProc();
+    bool checkReviveProc();
+
+
+    // JugemLap
+    void initFunc_Lap();
+    void doFunc_Lap();
+    void initFunc_LapStay();
+    void doFunc_LapStay();
+    void initFunc_LapEnd();
+    void doFunc_LapEnd();
+    bool checkLapProc();
+
+
+    // JugemDemo
+    static bool isDemoMode();
+    void initFunc_DemoHide();
+    void doFunc_DemoHide();
+    void initFunc_DemoIn();
+    void doFunc_DemoIn();
+    void initFunc_DemoWait();
+    void doFunc_DemoWait();
+    void initFunc_WaitDemoOut();
+    void doFunc_WaitDemoOut();
+    void initFunc_DemoOut();
+    void doFunc_DemoOut();
+    void initFunc_Ending();
+    void doFunc_Ending();
+
+
+    // JugemGoal
+    void initFunc_Goal();
+    void doFunc_Goal();
+    bool checkJugemAppearRank();
+    static Vec scGoalPoints0[4];
+
+
+    // JugemStart
+    void resetStartPosition();
+    void initFunc_StartWaitPermission();
+    void doFunc_StartWaitPermission();
+    void initFunc_StartWaitCamera();
+    void doFunc_StartWaitCamera();
+    void initFunc_StartDown();
+    void doFunc_StartDown();
+    void initFunc_StartWaitBlend();
+    void doFunc_StartWaitBlend();
+    void initFunc_StartCountDown();
+    void doFunc_StartCountDown();
+    void initFunc_StartUp();
+    void doFunc_StartUp();
+    void initFunc_StartWaitHide();
+    void doFunc_StartWaitHide();
+    void startNextAnime();
+
+    // End of external references.
 
     void signalGo()
     {
@@ -66,17 +194,90 @@ public:
 
     void setEndingState() { setState(0x16); }
 
-    u8 _158[0x178 - 0x158];   //
-    TAnmPlayer mAnmPlayer;    // 178
-    u8 _190[0x244 - 0x190];   //
-    u32 mDemoPattern;         // 244
-    u8 _248;                  //
-    u8 mKartNum;              // 249
-    u8 _24a[0x250 - 0x24a];   //
-    bool mIsAbleStart;        // 250    
-    u8 _251[0x26c - 0x251];   //
-    TJugemRodSignal *mSignal; // 26c
-    u8 _270[0x27c - 0x270];   //
+private:
+    static StateFuncSet<TJugem> sTable[23];
+    static f32 scJugemDistance;
+    static f32 scJugemHeight;
+    static f32 scEraseHeight;
+    static s16 sChaseDistance;
+    static f32 sChaseAccel;
+    static f32 sChaseDecel;
+    static f32 sChaseEndSpeed;
+    static s16 sShadowEraseFrame;
+    static TAnmInfo sAnmInfos_Start[5];
+    static TAnmInfo sAnmInfos_Lap[4];
+    static TAnmInfo sAnmInfos_Rescue[3];
+    static TAnmInfo sAnmInfos_Reverse[2];
+    static TAnmInfo sAnmInfos_Goal[1];
+    static TAnmInfo sAnmInfos_Demo1[3];
+    static TAnmInfo sAnmInfos_Demo2[3];
+    static TAnmInfo sAnmInfos_Demo3[3];
+    static TJugemAnmTableEntry sAnmStateTable[5];
+    static TJugemAnmTableEntry sDemoAnmStateTable[3];
+
+private:
+    // Private static declarations for other files.
+    // JugemLap
+    static f32 sLapMoveSpeed1;
+    static f32 sLapMoveSpeed2;
+    static f32 sAnimeStartFrame;
+    static f32 sLapPauseRatio;
+    static s16 sLastStayFrame;
+    static Vec scLapPointsIn_1p[10];
+    static Vec scLapPointsIn_multi[10];
+
+    // JugemReverse
+    static Vec scReversePoints2[4];
+    static Vec scReversePoints0_1p[5];
+    static Vec scReversePoints0_multi[5];
+    static const Vec scReversePoints1_multi[6];
+    static s16 scReverseJudgeTime;
+    static s16 scReviveJudgeTime;
+    static f32 sReverseEnterSpeed;
+    static f32 sReverseStaySpeed;
+    static f32 sReverseLeaveSpeed;
+
+    // JugemStart
+    static Vec scStartPoints0_1p[6];
+    static Vec scStartPoints0_2p[5];
+    static s16 sStartWaitCameraFrame;
+    static s16 sStartWaitBlendFrame;
+    static s16 sStartUpFrame;
+    static f32 sStartUpSpeed;
+    static f32 sStartDownSpeed;
+
+
+public:
+    AnmController *mAnmController[5];       // 158
+    AnmController *mDemoAnmController[3];   // 16c
+    TAnmPlayer mAnmPlayer;                  // 178
+    J3DAnmObjMaterial _190;                 // 190
+    TJugemItem *mJugemItem;                 // 1b0
+    TJugemHeadItem *mJugemHeadItem;         // 1b4
+    TBSplineInterp mSplineInterp;           // 1b8
+    JGeometry::TVec3f _208;                 // 208
+    JGeometry::TVec3f _214;                 // 214
+    JGeometry::TVec3f _220;                 // 220
+    JGeometry::TVec3f _22c;                 // 22c
+    JGeometry::TVec3f _238;                 // 238
+    u32 mDemoPattern;                       // 244
+    u8 mCameraNum;                          // 248
+    u8 mKartNum;                            // 249
+    u8 _24a[0x24c - 0x24a];                 // 24a
+    s32 _24c;                               // 24c - Some sort of lap number...?
+    bool mIsAbleStart;                      // 250
+    bool mIsStartPoint;                     // 251
+    u8 _252[0x254 - 0x252];                 // 252
+    DarkAnmPlayer *mDarkAnmPlayer;          // 254
+    TJugemItem *mItem[3];                   // 258 - Items on Lakitu's fishing rod at startup?
+    TJugemHeadItem *mHeadItem[2];           // 264 - Lakitu's caps.
+    TJugemRodSignal *mSignal;               // 26c - Lap Number, Final Lap, U-Turn sign etc.
+    u8 _270[0x274 - 0x270];                 // 270
+    u8 _274;                                // 274
+    u8 _275;                                // 275 // Unused?
+    u16 _276;                               // 276
+    u16 _278;                               // 278
+    u8 _27a[0x27c - 0x27a];                 // 27a
 }; // Size: 0x27c
 
 #endif

--- a/include/Shiraiwa/JugemRodItem.h
+++ b/include/Shiraiwa/JugemRodItem.h
@@ -1,12 +1,15 @@
 #ifndef JUGEMRODSIGNAL_H
 #define JUGEMRODSIGNAL_H
 
+#include "JSystem/J3D/J3DAnmTexPattern.h"
+#include "JSystem/JGeometry/Vec.h"
 #include "JSystem/JKernel/JKRHeap.h"
-#include "JSystem/JGeometry.h"
 #include "JSystem/J3D/J3DModel.h"
 #include "JSystem/J3D/J3DAnmTevRegKey.h"
 #include "JSystem/JParticle/JPAEmitter.h"
+#include "Sato/AnmController.h"
 #include "Sato/GeographyObj.h"
+#include "Sato/J3DAnmObject.h"
 #include "Shiraiwa/AnmPlayer.h"
 
 // probably inherited from TJugemMain
@@ -15,14 +18,19 @@
 class TJugemRodItem : public GeographyObj
 {
 public:
-    TJugemRodItem(u32 id) : GeographyObj(id) {}
+    TJugemRodItem(u32 id) : GeographyObj(id) {
+        setObjFlagHidding();
+    }
     virtual ~TJugemRodItem() {}
-    virtual void setPosition(const JGeometry::TVec3f &rPos) { mPos.set(rPos); } // 80
-    virtual void setRMtx(const JGeometry::TPos3f &rMtx) { mRotMtx.set(rMtx); }  // 84
-    virtual void show() { mGeoObjFlag &= ~0x20; }                               // 88
-    virtual void hide() { mGeoObjFlag |= ~0x20; }                               // 8C
-    virtual void hideAll() { hide(); }                                          // 90
-    virtual void changeAnimation(int) {}                                        // 94
+    virtual void setPosition(const JGeometry::TVec3f &rPos) { mPos.set(rPos); }       // 80
+    virtual void setRMtx(const JGeometry::TPos3f &rMtx) { mRotMtx.set(rMtx.mMtx); }  // 84
+    virtual void show(u8);                   // 88
+    virtual void hide();                     // 8C
+    virtual void hideAll() { hide(); }       // 90
+    virtual void changeAnimation(int) {}     // 94
+
+    static const s32 cJugemRodItem_Max;
+    TAnmPlayer mAnmPlayer;
 };
 
 class TJugemRodSignal : public TJugemRodItem
@@ -42,7 +50,7 @@ public:
     void startCountDown();                                     // 0x80293c60
     void show(u8);                                             // 0x80293c74
     void update();                                             // 0x80293cac
-    void isAcceptEffect();                                     // 0x80293e74
+    bool isAcceptEffect();                                     // 0x80293e74
 
     // Inline/Unused
     void getJointPos(JGeometry::TVec3f *, long);
@@ -53,7 +61,7 @@ public:
 
     static const char *scRedParticleName;           // 0x80415160
     static const char *scGreenParticleName;         // 0x80415164
-    static J3DAnmTevRegKey **sJugemRodSignalBrkAnm; // 0x80416da8
+    static J3DAnmTevRegKey *sJugemRodSignalBrkAnm;  // 0x80416da8
     static s16 sRandomWait;                         // 0x80416dac
     static int sLeftJointNo;                        // 0x80416db0
     static int sMiddleJointNo;                      // 0x80416db4
@@ -61,9 +69,15 @@ public:
     static const u8 scSignalInterval;               // 0x8041c7d8
     static const u8 scRandomLength;                 // UNUSED
 
-    u8 _14c[0x188 - 0x14c];
-    u32 _188;
-    u8 _18c[0x19c - 0x18c];
+    J3DAnmObjMaterial _164;         // 164
+    bool _184;                      // 184
+    //u8 _185[0x188 - 0x185];       // 185 - Padding.
+    s32 _188;                       // 188
+    u8 mKartCamIndex;               // 18c
+    //u8 _18d[0x190 - 0x18d];       // 18d - Padding.
+    JPABaseEmitter *mEmitterLeft;   // 190
+    JPABaseEmitter *mEmitterMiddle; // 194
+    JPABaseEmitter *mEmitterRight;  // 198
 }; // Size: 0x19c
 
 class TJugemRodPukuPuku : public TJugemRodItem
@@ -80,15 +94,79 @@ public:
     void setPosition(const JGeometry::TVec3<float> &);
     void setRMtx(const JGeometry::TPos3f &);
     void setCurrentViewNo(u32);
-    void nodeCallBack(J3DJoint *, int);
+    static bool nodeCallBack(J3DJoint *, int);
+
+    const char *getBmdFileName() { return "/Objects/puku_model.bmd"; }
+    u32 getJ3DModelDataTevStageNum() const { return 0x20020; }
+
     // Inline/Unused
     void getCurMatrix(Mtx);
     // void scCutFrame;
-    // void sAnmInfos_Puku_Demo2;
-    // void sAnmInfos_Puku_Demo3;
-    // void sDemoAnmStateTable;
+    static TAnmInfo sAnmInfos_Puku_Demo2[3];
+    static TAnmInfo sAnmInfos_Puku_Demo3[1];
+    static TJugemAnmTableEntry sDemoAnmStateTable[3];
+
 private:
-    u8 _14c[0x174 - 0x14c];
+    AnmController *mAnmController[3];
+    u8 _170;    // 0x170
+    s8 _171;    // 0x171
 }; // Size: 0x174
+
+
+class TJugemRodBoard : public TJugemRodItem {
+public:
+    TJugemRodBoard();
+    ~TJugemRodBoard();
+    void reset();
+    void loadAnimation();
+    const char *getBmdFileName();
+    void createModel(JKRSolidHeap *, u32);
+    void show(u8);
+    void update();
+    void calc();
+
+
+    static J3DAnmTexPattern *sJugemRodBoardBtpAnm;
+    static const f32 scObjScale[4];
+
+
+    J3DAnmObjMaterial _164;
+};
+
+class TJugemRodBoard2 : public TJugemRodItem {
+public:
+    TJugemRodBoard2();
+    ~TJugemRodBoard2();
+    void reset();
+    void loadAnimation();
+    const char *getBmdFileName();
+    void createModel(JKRSolidHeap *, u32);
+    void show(u8);
+    void update();
+    void calc();
+
+    static J3DAnmTevRegKey *sJugemRodBoard2BrkAnm;
+    static const f32 scObjScale[4];
+
+    J3DAnmObjMaterial _164;
+};
+
+class TJugemRodBoardRev : public TJugemRodItem {
+public:
+    TJugemRodBoardRev();
+    ~TJugemRodBoardRev();
+    void reset();
+    void loadAnimation();
+    const char *getBmdFileName();
+    void createModel(JKRSolidHeap *, u32);
+    void show(u8);
+    void update();
+    void calc();
+
+    static J3DAnmTevRegKey *sJugemRodBoardRevBrkAnm;
+    static const f32 scObjScale[4];
+
+    J3DAnmObjMaterial _164;
+};
 
 #endif

--- a/src/Sato/J3DAnmObject.cpp
+++ b/src/Sato/J3DAnmObject.cpp
@@ -1,0 +1,79 @@
+#include "JSystem/J3D/J3DAnmBase.h"
+#include "JSystem/J3D/J3DAnmCluster.h"
+#include "JSystem/J3D/J3DAnmLoader.h"   // Required to compile.
+#include "JSystem/J3D/J3DAnmTevRegKey.h"
+#include "JSystem/J3D/J3DClusterLoader.h"
+#include "JSystem/J3D/J3DFrameCtrl.h"
+#include "JSystem/J3D/J3DModel.h"
+#include "JSystem/J3D/J3DModelLoader.h"
+#include "types.h"
+#include "Sato/J3DAnmObject.h"
+
+
+void J3DAnmObjBase::loadJ3DModelData(void *param_1, u32 param_2) {
+    // FIX: Identify what the bitmask here is really used for.
+    J3DModelLoaderDataBase().load(this, (u32)param_1 | 0x19200010);
+}
+
+void J3DAnmObjBase::initFrameCtrl(J3DAnmBase *initAnmBase) {
+    mFrameCtrl.mAttr = initAnmBase->getAttribute();
+    mFrameCtrl.mEndFrame = initAnmBase->getFrameMax();
+}
+
+void J3DAnmObjTrans::loadTransAnm(J3DAnmTransform **anmTransform, void *param_2) {
+    *anmTransform = (J3DAnmTransform *)J3DAnmLoaderDataBase().load(param_2, J3DLOADER_UNK_FLAG0);
+}
+
+void J3DAnmObjTrans::setupTransAnmData(J3DAnmTransform **anmTransform,
+                                       J3DMtxCalc **mtxCalc,
+                                       J3DModelData *modelData,
+                                       void *param_4
+) {    
+    *anmTransform = (J3DAnmTransform *)J3DAnmLoaderDataBase().load(param_4, J3DLOADER_UNK_FLAG0);
+    *mtxCalc = J3DNewMtxCalcAnm(modelData->getMtxCalcType() & 0xf, *anmTransform);
+    return;
+}
+
+void J3DAnmObjTrans::attach(J3DAnmTransform *anmBase, J3DMtxCalc *mtxCalc) {
+    mAnmBase = anmBase;
+    mCalc = mtxCalc;
+    mFrameCtrl.mAttr = anmBase->getAttribute();
+    mFrameCtrl.mEndFrame = anmBase->getFrameMax();
+}
+
+void J3DAnmObjTrans::attachBlend(J3DAnmTransform *anmBase, J3DMtxCalc *mtxCalc) {
+    _28 |= 1;
+    mAnmBase = anmBase;
+    mCalc = mtxCalc;
+    mFrameCtrl.mAttr = anmBase->getAttribute();
+    mFrameCtrl.mEndFrame = anmBase->getFrameMax();
+}
+
+void J3DAnmObjTrans::anmFrameProc() {
+    mAnmBase->mCurrentFrame = mFrameCtrl.getFrame();
+}
+
+void J3DAnmObjMaterial::setupColorAnmData(J3DAnmColor **, J3DModelData *, void *) {}
+
+void J3DAnmObjMaterial::setupTexSRTAnmData(J3DAnmTextureSRTKey **, J3DModelData *, void *) {}
+
+void J3DAnmObjMaterial::setupTexPatternAnmData(J3DAnmTexPattern **, J3DModelData *, void *) {}
+
+void J3DAnmObjMaterial::setupTevRegAnmData(J3DAnmTevRegKey **param_1, J3DModelData *param_2, void *param_3) {}
+
+template<> void J3DAnmObjMaterial::setMaterialAnmTev<J3DAnmTevRegKey>(J3DAnmTevRegKey **param_1, J3DModelData *param_2) {
+    
+}
+
+void J3DAnmObjCluster::loadClusterData(J3DDeformData **, void *) {}
+
+void J3DAnmObjCluster::loadClusterAnmData(J3DAnmCluster **anmCluster, void *) {}
+
+void J3DAnmObjCluster::setDeformData(ExModel *param_1, J3DDeformData *param_2, bool param_3) {}
+
+void J3DAnmObjCluster::attach(J3DAnmCluster *anmCluster) {
+    mAnmBase = anmCluster;
+    J3DAnmBase *anmBase = mAnmBase;
+    mFrameCtrl.mAttr = anmBase->getAttribute();
+    mFrameCtrl.mEndFrame = anmBase->getFrameMax();
+}

--- a/src/Sato/ObjUtility.cpp
+++ b/src/Sato/ObjUtility.cpp
@@ -1,1 +1,21 @@
 #include "Sato/ObjUtility.h"
+#include "JSystem/JGeometry/Matrix.h"
+#include "JSystem/JGeometry/Vec.h"
+#include "JSystem/JUtility/JUTAssert.h"
+#include "Kaneshige/KartLoader.h"
+#include "Kaneshige/RaceMgr.h"
+#include "dolphin/mtx.h"
+
+void ObjUtility::executeShakeCamera(const JGeometry::TVec3f &inputVec, f32 f1, f32 f2, f32 f3) {}
+
+void ObjUtility::getKartPos(int kart_index, JGeometry::TVec3f *kartPos) {
+    int kart = kart_index;
+    #line 134
+    JUT_MINMAX_ASSERT(0, kart_index, 8);
+    #line 120
+    JUT_MINMAX_ASSERT(0, kart, 8);
+    KartLoader *kartObj = RaceMgr::sRaceManager->getKartLoader(kart_index);
+    kartObj->getExModelBody()->mBaseTRMtx.getTransInline(*kartPos);
+}
+
+void ObjUtility::getCamDependLightMtx(u32, const JGeometry::TVec3f &, Mtx) {}

--- a/src/Sato/ObjUtility.cpp
+++ b/src/Sato/ObjUtility.cpp
@@ -8,14 +8,6 @@
 
 void ObjUtility::executeShakeCamera(const JGeometry::TVec3f &inputVec, f32 f1, f32 f2, f32 f3) {}
 
-void ObjUtility::getKartPos(int kart_index, JGeometry::TVec3f *kartPos) {
-    int kart = kart_index;
-    #line 134
-    JUT_MINMAX_ASSERT(0, kart_index, 8);
-    #line 120
-    JUT_MINMAX_ASSERT(0, kart, 8);
-    KartLoader *kartObj = RaceMgr::sRaceManager->getKartLoader(kart_index);
-    kartObj->getExModelBody()->mBaseTRMtx.getTransInline(*kartPos);
-}
+void ObjUtility::getKartPos(int kart_index, JGeometry::TVec3f *kartPos) {}
 
 void ObjUtility::getCamDependLightMtx(u32, const JGeometry::TVec3f &, Mtx) {}

--- a/src/Shiraiwa/JugemDemo.cpp
+++ b/src/Shiraiwa/JugemDemo.cpp
@@ -1,0 +1,91 @@
+#include "Inagaki/GameAudioMain.h"
+#include "JSystem/JUtility/JUTAssert.h"
+#include "Kaneshige/RaceMgr.h"
+#include "Shiraiwa/JugemMain.h"
+
+bool TJugem::isDemoMode() {
+    return RaceMgr::getCurrentManager() == false;
+}
+
+void TJugem::initFunc_DemoHide() {
+    hideAll();
+}
+
+void TJugem::doFunc_DemoHide() {}
+
+void TJugem::initFunc_DemoIn() {
+    wearCap(0);
+#line 50
+    JUT_MINMAX_ASSERT(0, mDemoPattern, 3);
+    switch (mDemoPattern) {
+        case 0:
+            hold(1, 2);
+            changeAnimation(0);
+            break;
+
+        case 1:
+            hold(1, 5);
+            changeAnimation(1);
+            break;
+
+        case 2:
+            hold(1, 5);
+            changeAnimation(2);
+            break;
+
+        default:
+            break;
+    }
+    show(mDemoPattern);
+}
+
+void TJugem::doFunc_DemoIn() {
+    if (mAnmPlayer.getCurAnmNumber() != 0) {
+        setState(0x13);
+    }
+    GetGameAudioMain()->startSystemSe(0x20066);
+}
+
+void TJugem::initFunc_DemoWait() {}
+
+void TJugem::doFunc_DemoWait() {
+    GetGameAudioMain()->startSystemSe(0x20066);
+}
+
+void TJugem::initFunc_WaitDemoOut() {}
+
+void TJugem::doFunc_WaitDemoOut() {
+    GetGameAudioMain()->startSystemSe(0x20066);
+    if (mAnmPlayer.getCurAnmNumber() >= 1) {
+        setState(0x15);
+    }
+}
+
+void TJugem::initFunc_DemoOut() {
+    mAnmPlayer._10 = 1;
+    mAnmPlayer._e |= 2;
+    TJugemItem *tJugemItem = mJugemItem;
+    if (tJugemItem == nullptr) {
+        return;
+    }
+    tJugemItem->mJugemAnmPlayer._10 = 1;
+    tJugemItem->mJugemAnmPlayer._e |= 2;
+}
+
+void TJugem::doFunc_DemoOut() {
+    if (mAnmPlayer.getCurAnmNumber() >= 2) {
+        if (mAnmPlayer.getCurAnmNumber() == 2) {
+            if (mAnmPlayer.mController->getFrameCtrl(mAnmPlayer.mController->getNowTransNo())->getFrame() <= 1.0f) {
+                GetGameAudioMain()->startSystemSe(0x20067);
+            }
+        }
+    } else {
+        GetGameAudioMain()->startSystemSe(0x20066);
+    }
+}
+
+void TJugem::initFunc_Ending() {
+    hideAll();
+}
+
+void TJugem::doFunc_Ending() { }

--- a/src/Shiraiwa/JugemDemo.cpp
+++ b/src/Shiraiwa/JugemDemo.cpp
@@ -1,4 +1,5 @@
 #include "Inagaki/GameAudioMain.h"
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "Kaneshige/RaceMgr.h"
 #include "Shiraiwa/JugemMain.h"

--- a/src/Shiraiwa/JugemFlag.cpp
+++ b/src/Shiraiwa/JugemFlag.cpp
@@ -42,15 +42,9 @@ const char *TJugemFlag::getBmdFileName() {
 
 void TJugemFlag::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
     mModel.createModel(jkrSolidHeap, param_2, false);
-    AnmController *anmCtrl = mAnmCtrl;
-    anmCtrl->mTrans = new AnmControlTrans();
-    AnmControlTrans *anmCtrlTrans = anmCtrl->mTrans;
-
-    anmCtrlTrans->initAnm(1, &mModel);
-    mAnmCtrl->mTrans->registration(0, sJugemFlagBckAnmTrans, sJugemFlagBckMtxCalc);
-    anmCtrlTrans = mAnmCtrl->mTrans;
-
-    anmCtrlTrans->getFrameCtrl(0)->setAttribute(2);
+    getAnmCtrl()->InitRegistration(1, &mModel);
+    getAnmCtrl()->RegisterTrans(0, sJugemFlagBckAnmTrans, sJugemFlagBckMtxCalc);
+    getAnmCtrl()->getFrameCtrl(0)->setAttribute(2);
 }
 
 void TJugemFlag::createColModel(J3DModelData *j3dModelData) {}

--- a/src/Shiraiwa/JugemFlag.cpp
+++ b/src/Shiraiwa/JugemFlag.cpp
@@ -1,5 +1,7 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Sato/ObjUtility.h"
 #include "Shiraiwa/JugemItem.h"
+
 
 J3DAnmTransform *TJugemFlag::sJugemFlagBckAnmTrans;
 J3DMtxCalc *TJugemFlag::sJugemFlagBckMtxCalc;

--- a/src/Shiraiwa/JugemFlag.cpp
+++ b/src/Shiraiwa/JugemFlag.cpp
@@ -1,0 +1,58 @@
+#include "Sato/ObjUtility.h"
+#include "Shiraiwa/JugemItem.h"
+
+J3DAnmTransform *TJugemFlag::sJugemFlagBckAnmTrans;
+J3DMtxCalc *TJugemFlag::sJugemFlagBckMtxCalc;
+
+TJugemFlag::TJugemFlag() : TJugemItem(0x102) {
+    NewAnmCtrl();
+    reset();
+}
+
+TJugemFlag::~TJugemFlag() {}
+
+void TJugemFlag::reset() {
+    resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+}
+
+void TJugemFlag::loadAnimation() {
+    J3DAnmObjTrans::setupTransAnmData(
+        &sJugemFlagBckAnmTrans, 
+        &sJugemFlagBckMtxCalc, 
+        mModel.getModelData(), 
+        ObjUtility::getPtrMainArc("/Objects/jg_flag_wy.bca")
+    );
+}
+
+const char *TJugemFlag::getShadowBmdFileName() {
+    return nullptr;
+}
+
+const char *TJugemFlag::getBmdFileName() {
+    static const char *cBmdName = "/Objects/jg_flag.bmd";
+    return cBmdName;
+}
+
+void TJugemFlag::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createModel(jkrSolidHeap, param_2, false);
+    AnmController *anmCtrl = mAnmCtrl;
+    anmCtrl->mTrans = new AnmControlTrans();
+    AnmControlTrans *anmCtrlTrans = anmCtrl->mTrans;
+
+    anmCtrlTrans->initAnm(1, &mModel);
+    mAnmCtrl->mTrans->registration(0, sJugemFlagBckAnmTrans, sJugemFlagBckMtxCalc);
+    anmCtrlTrans = mAnmCtrl->mTrans;
+
+    anmCtrlTrans->getFrameCtrl(0)->setAttribute(2);
+}
+
+void TJugemFlag::createColModel(J3DModelData *j3dModelData) {}
+
+void TJugemFlag::changeAnimation(u32 param_1) { // TODO: Is this param just unused?
+    mAnmCtrl->Reset();
+}

--- a/src/Shiraiwa/JugemGoal.cpp
+++ b/src/Shiraiwa/JugemGoal.cpp
@@ -1,4 +1,6 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Shiraiwa/JugemMain.h"
+
 
 Vec TJugem::scGoalPoints0[4] = {
     { 0.0f,    0.0f, 0.0f },

--- a/src/Shiraiwa/JugemGoal.cpp
+++ b/src/Shiraiwa/JugemGoal.cpp
@@ -1,0 +1,29 @@
+#include "Shiraiwa/JugemMain.h"
+
+Vec TJugem::scGoalPoints0[4] = {
+    { 0.0f,    0.0f, 0.0f },
+    { 0.0f,  750.0f, 0.0f },
+    { 0.0f, -170.0f, 0.0f },
+    { 0.0f, -150.0f, 0.0f },
+};
+
+void TJugem::initFunc_Goal() {
+    if (!checkJugemAppearRank()) {  // o_O - checkJugemAppearRank always returns true...
+        setState(0);                // ... so this never gets executed? Why?!
+    } else {
+        wearCap(0);
+        hold(2, 0);
+        show(0);
+        changeAnimation(4);
+        resetJugemOriginNumber();
+        mSplineInterp.setPoint(4, &scGoalPoints0->x, 0.03f, false);
+    }
+}
+
+void TJugem::doFunc_Goal() {
+    move(getKartNum());
+}
+
+bool TJugem::checkJugemAppearRank() {
+    return true;
+}

--- a/src/Shiraiwa/JugemHeadLamp.cpp
+++ b/src/Shiraiwa/JugemHeadLamp.cpp
@@ -1,0 +1,96 @@
+#include "Sato/AnmController.h"
+#include "Sato/ObjUtility.h"
+#include "Shiraiwa/JugemHeadItem.h"
+#include "Shiraiwa/JugemMain.h"
+#include "Shiraiwa/SiUtil.h"
+#include "types.h"
+
+J3DAnmTevRegKey *TJugemHeadLamp::sJugemHeadLampBrkAnm;
+J3DAnmTransform *TJugemHeadLamp::sJugemHeadLampBcaAnm;
+J3DMtxCalc *TJugemHeadLamp::sJugemHeadLampBcaMtxCalc;
+
+TJugemHeadLamp::TJugemHeadLamp() : TJugemHeadItem(0x109) {
+    NewAnmCtrl();
+    setObjFlagNorm();
+}
+
+TJugemHeadLamp::~TJugemHeadLamp() {}
+
+void TJugemHeadLamp::reset() {
+    resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    mAnmCtrl->Reset();
+    _150.resetFrame();
+}
+
+void TJugemHeadLamp::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    J3DAnmObjTrans::setupTransAnmData(&sJugemHeadLampBcaAnm, &sJugemHeadLampBcaMtxCalc, modelData, ObjUtility::getPtrMainArc("/Objects/jg_patlamp.bca"));
+    J3DAnmObjMaterial::setupTevRegAnmData(&sJugemHeadLampBrkAnm, modelData, ObjUtility::getPtrMainArc("/Objects/jg_patlamp.brk"));
+}
+
+void TJugemHeadLamp::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createDifferedModel(jkrSolidHeap, param_2, 0x1000000, false);
+    AnmController *anmCtrl = mAnmCtrl;
+    anmCtrl->mTrans = new AnmControlTrans();
+    AnmControlTrans *anmCtrlTrans = anmCtrl->mTrans;
+
+    anmCtrlTrans->initAnm(1, &mModel);
+    mAnmCtrl->mTrans->registration(0, sJugemHeadLampBcaAnm, sJugemHeadLampBcaMtxCalc);
+    anmCtrlTrans = mAnmCtrl->mTrans;
+
+    mAnmCtrl->mTrans->getFrameCtrl(0)->setAttribute(2);
+    _150.mModel = &mModel;
+    _150.setAnmBase(sJugemHeadLampBrkAnm);
+    _150.initFrameCtrl(_150.getAnmBase());
+}
+
+const char *TJugemHeadLamp::getBmdFileName() {
+    static const char *cBmdName = "/Objects/jg_patlamp.bmd";
+    return cBmdName;
+}
+
+void TJugemHeadLamp::calc() {
+    _150.update();
+}
+
+void TJugemHeadLamp::update() {
+    _150.anmFrameProc();
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+TJugemHeadHear::TJugemHeadHear() : TJugemHeadItem(0x100) {
+    reset();
+    setObjFlagNorm();
+}
+
+TJugemHeadHear::~TJugemHeadHear() {}
+
+void TJugemHeadHear::reset() {
+    resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+}
+
+const char *TJugemHeadHear::getBmdFileName() {
+    int index = 0;
+    
+    if (TJugem::isDemoMode() == false && SiUtil::getConsoleNum() != 1) {
+        index = 1;
+    }
+
+    static const char *cBmdName[2] = {
+        "/Objects/jg_hair_model.bmd",
+        "/Objects/jg_hair_modelL.bmd"
+    };
+    
+    return cBmdName[index];
+}

--- a/src/Shiraiwa/JugemHeadLamp.cpp
+++ b/src/Shiraiwa/JugemHeadLamp.cpp
@@ -1,9 +1,11 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Sato/AnmController.h"
 #include "Sato/ObjUtility.h"
 #include "Shiraiwa/JugemHeadItem.h"
 #include "Shiraiwa/JugemMain.h"
 #include "Shiraiwa/SiUtil.h"
 #include "types.h"
+
 
 J3DAnmTevRegKey *TJugemHeadLamp::sJugemHeadLampBrkAnm;
 J3DAnmTransform *TJugemHeadLamp::sJugemHeadLampBcaAnm;

--- a/src/Shiraiwa/JugemLap.cpp
+++ b/src/Shiraiwa/JugemLap.cpp
@@ -1,3 +1,4 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Kaneshige/RaceMgr.h"
 #include "Sato/AnmController.h"
 #include "Shiraiwa/JugemMain.h"

--- a/src/Shiraiwa/JugemLap.cpp
+++ b/src/Shiraiwa/JugemLap.cpp
@@ -1,0 +1,101 @@
+#include "Kaneshige/RaceMgr.h"
+#include "Sato/AnmController.h"
+#include "Shiraiwa/JugemMain.h"
+
+f32 TJugem::sLapMoveSpeed1 = 0.056f;
+f32 TJugem::sLapMoveSpeed2 = 0.045f;
+f32 TJugem::sAnimeStartFrame = 60.0f;
+f32 TJugem::sLapPauseRatio = 5.5f;
+s16 TJugem::sLastStayFrame = 0x32;
+
+Vec TJugem::scLapPointsIn_1p[10] = {
+    { 400.0f, 1000.0f, -300.0f },
+    { 400.0f, -170.0f, -400.0f },
+    { 400.0f, -150.0f, -450.0f },
+    { 400.0f,  140.0f, -500.0f },
+    { 400.0f,  120.0f, -500.0f },
+    { 400.0f,  -50.0f, -500.0f },
+    { 400.0f,  100.0f, -500.0f },
+    { 400.0f,  100.0f, -500.0f },
+    { 400.0f, -450.0f, -500.0f },
+    { 400.0f,    0.0f, -500.0f },
+};
+
+Vec TJugem::scLapPointsIn_multi[10] = {
+    { 550.0f, 1000.0f, -300.0f },
+    { 550.0f,  -90.0f, -300.0f },
+    { 550.0f,  -70.0f, -450.0f },
+    { 550.0f,  160.0f, -500.0f },
+    { 550.0f,  140.0f, -500.0f },
+    { 550.0f,  -30.0f, -500.0f },
+    { 550.0f,  120.0f, -500.0f },
+    { 550.0f,  120.0f, -500.0f },
+    { 550.0f, -310.0f, -500.0f },
+    { 550.0f,    0.0f, -500.0f },
+};
+
+void TJugem::initFunc_Lap() {
+    wearCap(0);
+    if (_24c == RaceMgr::getCurrentManager()->getTotalLapNumber() - 1) {
+        hold(1, 3);
+        show(0);
+    } else {
+        hold(1, 1);
+        show(_24c - 1);
+    }
+    changeAnimation(1);
+
+    AnmController *anmController = mAnmPlayer.mController;
+    anmController->getFrameCtrl(anmController->getNowTransNo())->setFrame(sAnimeStartFrame);
+    anmController = mJugemItem->mJugemAnmPlayer.mController;
+    anmController->getFrameCtrl(anmController->getNowTransNo())->setFrame(sAnimeStartFrame);
+
+    switch (getScreenType()) {
+        case 0:
+            mSplineInterp.setPoint(10, &scLapPointsIn_1p->x, sLapMoveSpeed1, false);
+            break;
+        case 1:
+        case 2:
+            mSplineInterp.setPoint(10, &scLapPointsIn_multi->x, sLapMoveSpeed1, false);
+            break;
+        default:
+            break;
+    }
+    resetJugemOriginNumber();
+}
+
+void TJugem::doFunc_Lap() {
+    move(getKartNum());
+    if (mSplineInterp.getUnknownValue10() + mSplineInterp.getRatio() >= sLapPauseRatio) {
+        setState(3);
+    }
+}
+
+void TJugem::initFunc_LapStay() {}
+
+void TJugem::doFunc_LapStay() {
+    move(getKartNum());
+    if (getStateCount() > TJugem::sLastStayFrame) {
+        setState(4);
+    }
+}
+
+void TJugem::initFunc_LapEnd() {
+    mSplineInterp.setSpeed(sLapMoveSpeed2);
+}
+
+void TJugem::doFunc_LapEnd() {
+    move(getKartNum());
+    if (mSplineInterp.getUnknownValue10() + mSplineInterp.getRatio() > 9.1f) {
+        setState(1);
+    }
+}
+
+bool TJugem::checkLapProc() {
+    s32 lap = RaceMgr::getCurrentManager()->getKartChecker(getKartNum())->getLap();
+    if (lap > _24c) {
+        _24c = lap;
+        return true;
+    }
+    return false;
+}

--- a/src/Shiraiwa/JugemMain.cpp
+++ b/src/Shiraiwa/JugemMain.cpp
@@ -1,6 +1,7 @@
 #include "JSystem/J3D/J3DJoint.h"
 #include "JSystem/J3D/J3DModel.h"
 #include "JSystem/J3D/J3DSys.h"
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "JSystem/JGeometry/Matrix.h"
 #include "JSystem/JGeometry/Quat.h"
 #include "JSystem/JGeometry/Util.h"

--- a/src/Shiraiwa/JugemMain.cpp
+++ b/src/Shiraiwa/JugemMain.cpp
@@ -1,7 +1,6 @@
 #include "JSystem/J3D/J3DJoint.h"
 #include "JSystem/J3D/J3DModel.h"
 #include "JSystem/J3D/J3DSys.h"
-#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "JSystem/JGeometry/Matrix.h"
 #include "JSystem/JGeometry/Quat.h"
 #include "JSystem/JGeometry/Util.h"
@@ -691,11 +690,6 @@ void TJugem::localMove(JGeometry::TVec3f *vec) {
     }
 
     static JGeometry::TQuat4f qtAxisY;
-    // FIX: Is some init code missing from the quaternion implementation?
-    // static s8 init;
-    // if (!init) {
-    //     init = 1;
-    // }
 
     f32 dx = vec->x - _22c.x;
     f32 dz = vec->z - _22c.z;

--- a/src/Shiraiwa/JugemMain.cpp
+++ b/src/Shiraiwa/JugemMain.cpp
@@ -1,0 +1,1175 @@
+#include "JSystem/J3D/J3DJoint.h"
+#include "JSystem/J3D/J3DModel.h"
+#include "JSystem/J3D/J3DSys.h"
+#include "JSystem/JGeometry/Matrix.h"
+#include "JSystem/JGeometry/Quat.h"
+#include "JSystem/JGeometry/Util.h"
+#include "JSystem/JGeometry/Vec.h"
+#include "JSystem/JKernel/JKRHeap.h"
+#include "JSystem/JMath/JMath.h"
+#include "JSystem/JUtility/JUTAssert.h"
+#include "JSystem/JUtility/JUTNameTab.h"
+#include "Kaneshige/Course/Course.h"
+#include "Kaneshige/Course/CrsArea.h"
+#include "Kaneshige/Course/CrsGround.h"
+#include "Kaneshige/DarkAnmMgr.h"
+#include "Kaneshige/ExModel.h"
+#include "Kaneshige/Movie/MovieApp.h"
+#include "Kaneshige/RaceMgr.h"
+#include "Osako/ResMgr.h"
+#include "Sato/AnmController.h"
+#include "Sato/GeographyObj.h"
+#include "Sato/ObjUtility.h"
+#include "Shiraiwa/AnmPlayer.h"
+#include "Shiraiwa/JugemHeadItem.h"
+#include "Shiraiwa/JugemItem.h"
+#include "Shiraiwa/SiUtil.h"
+#include "Yamamoto/kartBody.h"
+#include "Yamamoto/kartCtrl.h"
+#include "dolphin/mtx.h"
+#include "dolphin/types.h"
+#include "types.h"
+#include "Shiraiwa/JugemMain.h"
+
+f32 TJugem::scJugemDistance = 700.0f;
+f32 TJugem::scJugemHeight = 200.0f;
+f32 TJugem::scEraseHeight = 7000.0f;
+static const u8 scJugemCameraMax = 4;
+s16 TJugem::sChaseDistance = 0x3c;
+f32 TJugem::sChaseAccel = 0.5f;
+f32 TJugem::sChaseDecel = 0.6f;
+f32 TJugem::sChaseEndSpeed = 0.0001f;
+s16 TJugem::sShadowEraseFrame = 0x1e;
+
+// ORDER IS IMPORTANT - Ordered correctly for [.data-0] segment.
+StateObserver::StateFuncSet<TJugem> TJugem::sTable[23] = {
+    {   0, &TJugem::initFunc_Wait, &TJugem::doFunc_Wait},
+    {   1, &TJugem::initFunc_Erase, &TJugem::doFunc_Erase},
+    {   2, &TJugem::initFunc_Lap, &TJugem::doFunc_Lap},
+    {   3, &TJugem::initFunc_LapStay, &TJugem::doFunc_LapStay},
+    {   4, &TJugem::initFunc_LapEnd, &TJugem::doFunc_LapEnd},
+    {   5, &TJugem::initFunc_Reverse, &TJugem::doFunc_Reverse},
+    {   6, &TJugem::initFunc_RevEnd, &TJugem::doFunc_RevEnd},
+    {   7, &TJugem::initFunc_RescueWait, &TJugem::doFunc_RescueWait},
+    {   8, &TJugem::initFunc_Rescue, &TJugem::doFunc_Rescue},
+    {   9, &TJugem::initFunc_Goal, &TJugem::doFunc_Goal},
+    { 10, &TJugem::initFunc_StartWaitPermission, &TJugem::doFunc_StartWaitPermission},
+    { 11, &TJugem::initFunc_StartWaitCamera, &TJugem::doFunc_StartWaitCamera},
+    { 12, &TJugem::initFunc_StartDown, &TJugem::doFunc_StartDown},
+    { 13, &TJugem::initFunc_StartWaitBlend, &TJugem::doFunc_StartWaitBlend},
+    { 14, &TJugem::initFunc_StartCountDown, &TJugem::doFunc_StartCountDown},
+    { 15, &TJugem::initFunc_StartUp, &TJugem::doFunc_StartUp},
+    { 16, &TJugem::initFunc_StartWaitHide, &TJugem::doFunc_StartWaitHide},
+    { 17, &TJugem::initFunc_DemoHide, &TJugem::doFunc_DemoHide},
+    { 18, &TJugem::initFunc_DemoIn, &TJugem::doFunc_DemoIn},
+    { 19, &TJugem::initFunc_DemoWait, &TJugem::doFunc_DemoWait},
+    { 20, &TJugem::initFunc_WaitDemoOut, &TJugem::doFunc_WaitDemoOut},
+    { 21, &TJugem::initFunc_DemoOut, &TJugem::doFunc_DemoOut},
+    { 22, &TJugem::initFunc_Ending, &TJugem::doFunc_Ending},
+};
+
+TJugemAnmTableEntry TJugem::sAnmStateTable[5] = {
+    { sAnmInfos_Start,   5 },
+    { sAnmInfos_Lap,     4 },
+    { sAnmInfos_Rescue,  3 },
+    { sAnmInfos_Reverse, 2 },
+    { sAnmInfos_Goal,    1 },    // ...THUNDERBIRDS ARE GO!
+};
+
+TJugemAnmTableEntry TJugem::sDemoAnmStateTable[3] = {
+    { sAnmInfos_Demo1, 3 },
+    { sAnmInfos_Demo2, 3 },
+    { sAnmInfos_Demo3, 3 },
+};
+
+TAnmInfo TJugem::sAnmInfos_Start[5] = {
+    { "/Objects/jg_th.bca", nullptr, nullptr, 0, 60, 1, 1, 0 },
+    { "/Objects/jg_ww.bca", nullptr, nullptr, 2, 60, 0, 2, 0 },
+    { "/Objects/jg_cd.bca", nullptr, nullptr, 0, 10, 1, 3, 0 },
+    { "/Objects/jg_go.bca", nullptr, nullptr, 0, 60, 1, 4, 0 },
+    { "/Objects/jg_wz.bca", nullptr, nullptr, 2, 0, 0, 255, 0 },
+};
+TAnmInfo TJugem::sAnmInfos_Lap[4] = {
+    { "/Objects/jg_wz2fg.bca", nullptr, nullptr, 0, 30, 1, 1, 0 },
+    { "/Objects/jg_lk.bca", nullptr, nullptr, 2, 30, 2, 2, 0 },
+    { "/Objects/jg_by.bca", nullptr, nullptr, 2, 30, 2, 3, 0 },
+    { "/Objects/jg_wz.bca", nullptr, nullptr, 2, 0, 0, 255, 0 },
+};
+TAnmInfo TJugem::sAnmInfos_Rescue[3] = {
+    { "/Objects/jg_ca.bca", nullptr, nullptr, 2, 0, 0, 1, 0 },
+    { "/Objects/jg_cu.bca", nullptr, nullptr, 0, 0, 0, 2, 0 },
+    { "/Objects/jg_wz.bca", nullptr, nullptr, 2, 0, 0, 255, 0 },
+};
+TAnmInfo TJugem::sAnmInfos_Reverse[2] = {
+    { "/Objects/jg_no.bca", nullptr, nullptr, 2, 30, 6, 1, 0 },
+    { "/Objects/jg_st.bca", nullptr, nullptr, 2, 30, 6, 0, 0 },
+};
+TAnmInfo TJugem::sAnmInfos_Goal[1] = {
+    { "/Objects/jg_wy.bca", nullptr, nullptr, 2, 0, 0, 255, 0 }
+};
+
+
+TAnmInfo TJugem::sAnmInfos_Demo1[3] = {
+    { "/Objects/jg_in_a.bck", nullptr, nullptr, 0, 0, 1, 1, 0 },
+    { "/Objects/jg_wait.bck", nullptr, nullptr, 2, 0, 0, 2, 0 },
+    { "/Objects/jg_out.bck", nullptr, nullptr, 0, 0, 1, 255, 0 },
+};
+
+TAnmInfo TJugem::sAnmInfos_Demo2[3] = {
+    { "/Objects/jg_in_b.bck", nullptr, nullptr, 0, 0, 1, 1, 0 },
+    { "/Objects/jg_wait.bck", nullptr, nullptr, 2, 0, 0, 2, 0 },
+    { "/Objects/jg_out.bck", nullptr, nullptr, 0, 0, 1, 255, 0 },
+};
+
+TAnmInfo TJugem::sAnmInfos_Demo3[3] = {
+    { "/Objects/jg_in_c.bck", nullptr, nullptr, 0, 0, 1, 1, 0 },
+    { "/Objects/jg_wait.bck", nullptr, nullptr, 2, 0, 0, 2, 0 },
+    { "/Objects/jg_out.bck", nullptr, nullptr, 0, 0, 1, 255, 0 },
+};
+
+TJugem::TJugem() : TMapObjHioNode(0xFF), mJugemItem(nullptr), mJugemHeadItem(nullptr) {
+    mSignal = nullptr;
+
+    if (isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            mDemoAnmController[i] = new AnmController();
+        }
+    } else {
+        for (int i = 0; i < 5; i++) {
+            mAnmController[i] = new AnmController();
+        }
+    }
+
+    mCameraNum = 0;
+    mKartNum = 0;
+
+    mSplineInterp.init(&_208);
+
+    for (int i = 0; i < 3; i++) {
+        mItem[i] = nullptr;
+    }
+
+    for (int i = 0; i < 2; i++) {
+        mHeadItem[i] = nullptr;
+    }
+
+    mDarkAnmPlayer = nullptr;
+    if (!isDemoMode()) {
+        mDarkAnmPlayer = new ObjDarkAnmPlayer(mKind);
+    }
+    
+    resetStaticData();
+    reset();
+}
+
+TJugem::~TJugem() {
+    AnmController *anmController;
+    if (isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            delete mDemoAnmController[i];
+        }
+    } else {
+        for (int i = 0; i < 5; i++) {
+            delete mAnmController[i];
+        }
+    }
+}
+
+void TJugem::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    if (isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            TAnmPlayer::loadAnimations(sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize, modelData, ResMgr::mcArcOpening);
+        }
+    } else {
+        for (int i = 0; i < 5; i++) {
+            TAnmPlayer::loadAnimations(sAnmStateTable[i].tAnmInfo, sAnmStateTable[i].arraySize, modelData, ResMgr::mcArcMRAM);
+        }
+    }
+
+    for (u16 i = 0; i < modelData->getShapeNum(); i++) {
+        modelData->getShapeNodePointer(i)->setTexMtxLoadType(0x2000);
+    }
+}
+
+void TJugem::resetStaticData() {
+    if (isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            TAnmPlayer::resetAnimations(sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize);
+        }
+    } else {
+        for (int i = 0; i < 5; i++) {
+            TAnmPlayer::resetAnimations(sAnmStateTable[i].tAnmInfo, sAnmStateTable[i].arraySize);
+        }
+    }
+}
+
+void TJugem::reset() {
+    GeographyObj::resetObject();
+    _58 = 0;
+    mCheckKartHitFlags = 0;
+
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+
+    if (mDarkAnmPlayer != nullptr) {
+        mDarkAnmPlayer->reset();
+    }
+
+    mDemoPattern = 0;
+    _24c = 0;
+    _276 = 0;
+    _278 = 0;
+    _208.zero();
+    _220.zero();
+    _214.zero();
+    _22c.zero();
+    _238.zero();
+    mIsAbleStart = false;
+    _274 = 1;
+    mIsStartPoint = true;
+
+    ResetState();
+    if (isDemoMode()) {
+        setState(0x11);
+    } else {
+        resetStartPosition();
+    }
+}
+
+void TJugem::hold(u32 id, u32 param_2) {
+    if (mJugemItem != nullptr) {
+        mJugemItem->hide();
+    }
+
+#line 367
+    JUT_MINMAX_ASSERT(0, id, 3);
+    if (mItem[id] != nullptr) {
+        mJugemItem = mItem[id];
+        mJugemItem->hold(param_2);
+    }
+}
+
+void TJugem::setJugemItem(TJugemItem *tJugemItem, u32 id) {
+#line 382
+    JUT_MINMAX_ASSERT(0, id, 3);
+    mItem[id] = tJugemItem;
+    tJugemItem->mJugemParentPtr = (int)this;
+}
+
+void TJugem::setJugemHeadItem(TJugemHeadItem *tJugemHeadItem, u32 id) {
+#line 394
+    JUT_MINMAX_ASSERT(0, id, 2);
+    mHeadItem[id] = tJugemHeadItem;
+    tJugemHeadItem->mJugemParentPtr = (int)this;
+}
+
+const char *TJugem::getShadowBmdFileName() {
+    static const char *cShadowBmdName = "/Objects/jg_shadow.bmd";
+    return cShadowBmdName;
+}
+
+const char *TJugem::getBmdFileName() {
+    int index = 0;
+    if (!isDemoMode() && SiUtil::getConsoleNum() != 1) {
+        index = 1;
+    }
+    static const char *cBmdName[2] = {
+        "/Objects/jg_model.bmd",
+        "/Objects/jg_modelL.bmd"
+    };
+    return cBmdName[index];
+}
+
+void TJugem::createModel(JKRSolidHeap *param_1, u32 param_2) {
+    mModel.createDifferedModel(param_1, param_2, 0x1000200, 1);
+
+    u16 idx = mModel.getModelData()->getJointName()->getIndex("ef_head");
+    J3DJoint* joint = mModel.getModelData()->getJointNodePointer(idx);
+    joint->setCallBack(nodeCallBack);
+
+    mModel._14 = nullptr;
+    if (isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            TAnmPlayer::registAnimations(mDemoAnmController[i], &mModel, sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize);
+        }
+    } else {
+        for (int i = 0; i < 5; i++) {
+            TAnmPlayer::registAnimations(mAnmController[i], &mModel, sAnmStateTable[i].tAnmInfo, sAnmStateTable[i].arraySize);
+        }
+    }
+}
+
+void TJugem::setCurrentViewNo(u32 viewNo) {
+    mModel.setCurrentViewNo(viewNo);
+    
+    MtxPtr effectMtx;
+    if (!isDemoMode()) {
+        effectMtx = RaceMgr::getCurrentManager()->getKartDrawer(getKartNum())->getLight(viewNo)->getEffectMtx();
+    } else {
+        effectMtx = MovieApp::getMovieApp()->getMdlViewer()->getChaseLight()->getEffectMtx();
+    }
+    mModel.setEffectMtx(effectMtx, 1);
+}
+
+void TJugem::createColModel(J3DModelData *) {}
+
+void TJugem::createShadowModel(JKRSolidHeap *jkrSolidHeap, u32 p2) {
+    GeographyObj::createShadowModel(jkrSolidHeap, p2);
+
+    if (getShadowModel() != nullptr) {
+        for (u32 cnsNo = 0; cnsNo < RaceMgr::getCurrentManager()->mRaceInfo->mPlayerNum; cnsNo++) {
+            if (cnsNo == mCameraNum) {
+                ShadowModel *shadowModel = mShadowMdl;
+                shadowModel->setVisible(cnsNo);
+            }
+        }
+    }
+}
+
+void TJugem::viewCalc(u32 param_1) {
+    if (checkVisible(param_1) != 0) {
+        mModel.clipAll(param_1, false);
+        TJugemItem *tJugemItem = mJugemItem;
+        if (tJugemItem != nullptr) {
+            tJugemItem->hideModel(param_1);
+        }
+        TJugemHeadItem *tJugemHeadItem = mJugemHeadItem;
+        if (tJugemHeadItem != nullptr) {
+            tJugemHeadItem->hideModel(param_1);
+        }
+    }
+    mModel.viewCalc(param_1);
+}
+
+bool TJugem::checkVisible(u32 unknownVisibilityParam) {
+    if ((unknownVisibilityParam == 3) && (RaceMgr::sRaceManager->mRaceInfo->mStatusNum == 3)) {
+        return GetKartCtrl()->getKartCam(3)->GetTargetNum() != mCameraNum;
+    }
+    return unknownVisibilityParam != (u8)mCameraNum;
+}
+
+void TJugem::initFunc_Erase() {}
+
+void TJugem::doFunc_Erase() {
+    f32 normalisedRange = SiUtil::getNormalRange(getStateCount(), 0.0f, sShadowEraseFrame);
+
+    getShadowModel()->setAlpha((1.0f - normalisedRange) * 255.0f);
+    if ((1.0f - normalisedRange) <= 0.0f) {
+        setState(0);
+    }
+}
+
+void TJugem::initFunc_Wait() {
+    hideAll();
+    AnmControlTrans *anmControlTrans = getAnmCtrl()->mTrans;
+    if (anmControlTrans != nullptr) {
+        anmControlTrans->setFlag();
+    }
+
+    if (mJugemItem == nullptr) return;
+    if (mJugemItem->getAnmCtrl() == nullptr) return;
+    if (mJugemItem->getAnmCtrl()->mTrans == 0) return;
+
+    mJugemItem->getAnmCtrl()->mTrans->setFlag();
+}
+
+void TJugem::doFunc_Wait() {
+    if (checkLapProc() != 0) {
+        if (RaceMgr::getCurrentManager()->getKartChecker(getKartNum())->isGoal() != false) {
+            setState(9);
+        } else {
+            setState(2);
+        }
+    } else if (checkReverseProc() != 0) {
+        setState(5);
+    }
+}
+
+void TJugem::calc() {
+    ExecuteState();
+    if ((mGeoObjFlag & 0x20) == 0) {
+        mAnmPlayer.update();
+        CrsArea crsArea;
+        crsArea.search(0, mPos);
+
+        if (mDarkAnmPlayer != nullptr) {
+            mDarkAnmPlayer->calc(crsArea);
+        }
+    }
+
+    if (checkRescueInProc() != false) {
+        setState(7);
+    }
+}
+
+void TJugem::update() {
+    if (mDarkAnmPlayer != nullptr) {
+        mDarkAnmPlayer->setTevColor(&mModel);
+    }
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+void TJugem::resetJugemOriginCourse() {
+    JGeometry::TVec3f coursePos;
+    JGeometry::TVec3f jugemPos;
+
+    mIsStartPoint = RaceMgr::sRaceManager->getStartPoint(&coursePos, &jugemPos, mKartNum);
+    coursePos.y += RaceMgr::sRaceManager->getStartJugemOffsetY(mKartNum);
+    coursePos.y += 75.0f;
+    resetJugemOrigin(coursePos, jugemPos);
+}
+
+void TJugem::resetJugemOriginNumber() {
+    JGeometry::TVec3f kartPos;
+    JGeometry::TVec3f jugemPos;
+    
+    ObjUtility::getKartPos(mKartNum, &kartPos);
+    getZDir(mKartNum, &jugemPos);
+    resetJugemOrigin(kartPos, jugemPos);
+}
+
+void TJugem::getZDir(int param_1, JGeometry::TVec3f *vecZDir) {
+    JGeometry::TVec3f local_58;
+    JGeometry::TVec3f kartZDir;
+    
+    ObjUtility::getKartZdir(param_1, &local_58);
+    if (checkKartCrash()) {
+        kartZDir.set(_238);
+    }
+    else {
+        kartZDir.x = local_58.x;
+        kartZDir.y = 0.0;
+        kartZDir.z = local_58.z;
+    }
+
+    local_58.squared();
+    kartZDir.normalize();
+
+    if (kartZDir.isZero()) {
+        kartZDir.x = 1.0;
+        kartZDir.y = 0.0;
+        kartZDir.z = 0.0;
+    }
+
+    vecZDir->set(kartZDir);
+    _238.set(kartZDir);
+}
+
+// TODO: Once we work out correct JGeometry implementations for TRot3f and TQuat4f,
+//      this template below can be uncommented and adjusted as needed.
+// template <>
+// inline void JGeometry::TRot3f::setRotate(const TVec3f &a, const TVec3f &b) {
+//     TQuat4f q;
+//     q.setRotate(a, b);
+//     setQuat(q);
+// }
+
+void TJugem::resetJugemOrigin(const JGeometry::TVec3f &param_1, const JGeometry::TVec3f &param_2) {
+    JGeometry::TVec3f jugemOrigin;
+    JGeometry::TVec3f newPos;
+    
+    _22c.set(param_1);
+    getJugemOrigin(param_2, &jugemOrigin);
+    globalMove(&jugemOrigin);
+
+    _214.set(jugemOrigin);
+    localMove(&jugemOrigin);
+    setPosition(jugemOrigin);
+
+    newPos.sub(_22c, mPos);
+    newPos.y = 0.0f;
+
+    newPos.squaredZX();
+    newPos.normalize();
+
+    static JGeometry::TVec3f zAxis(0.0f, 0.0f, 1.0f);
+    mRotMtx.setRotate(zAxis, newPos);
+}
+
+void TJugem::getJugemOrigin(const JGeometry::TVec3f &param_1, JGeometry::TVec3f *param_2) {
+    JGeometry::TVec3f temp;
+    temp.set(param_1);
+    temp.setLength(scJugemDistance);
+
+    if (temp.y < 0.0f) {
+        temp.y = 200.0f;
+    } else {
+        temp.y += 200.0f;
+    }
+
+    param_2->set(temp);
+}
+
+void TJugem::move(int kartIndex) {
+    JGeometry::TVec3f local_c8;
+    JGeometry::TVec3f local_d4;
+    JGeometry::TVec3f kartPosCopy;
+    JGeometry::TVec3f kartPosDiff;
+    JGeometry::TVec3f local_f8;
+    JGeometry::TVec3f local_104;
+    JGeometry::TVec3f local_110;
+    JGeometry::TVec3f kartZDir;
+    JGeometry::TVec3f local_128;
+    
+    if (tstObjFlagHidding() != 0) {
+        return;
+    }
+
+    if (_274 != 0) {
+        ObjUtility::getKartPos(kartIndex, &_22c);
+        kartPosCopy = _22c;
+        kartPosDiff.sub(_22c, kartPosCopy);
+
+        const f32 kSnapThreshold = 0.1f;
+        if (kartPosDiff.squared() < kSnapThreshold) {
+            _22c.x = kartPosCopy.x;
+            _22c.y = kartPosCopy.y;
+            _22c.z = kartPosCopy.z;
+        }
+    }
+
+    ObjUtility::getKartZdir(kartIndex, &kartZDir);
+    if (checkKartCrash()) {
+        local_110.set(_238);
+    } else {
+        local_110.set(kartZDir.x, 0.0f, kartZDir.z);
+    }
+
+    local_110.normalize();
+
+    if (local_110.isZero()) {
+        local_110.set(1.0f, 0.0f, 0.0f);
+    }
+    
+    local_d4.set(local_110);
+    _238.set(local_110);
+    local_128.set(local_d4);
+    local_128.setLength(scJugemDistance);
+    
+    if (local_128.y < 0.0f) {
+        local_128.y = 200.0f;
+    } else {
+        local_128.y += 200.0f;
+    }
+
+    local_c8.set(local_128);
+    globalMove(&local_c8);
+    chase(kartIndex, local_c8, _214, local_c8);
+    _214.set(local_c8);
+    mSplineInterp.update();
+
+    localMove(&local_c8);
+
+    f32 limitY = 5.0f;
+
+    switch (getState()) {
+        
+        case 5:
+            if (mSplineInterp.checkUnknownBool13() != 0) {
+                limitY = 10.0f;
+            }
+            break;
+        case 9:
+            limitY = 15.0f;
+            break;
+
+        default:
+            break;
+    }
+
+    fixPosition(&local_c8, limitY);
+    mVel.sub(local_c8, mPos);
+    setPosition(local_c8);
+
+    if (getGlobalState() == 1) {
+        if (checkKartCrash()) {
+            mRotMtx.getZDirInline(local_d4);
+        } else {
+            ObjUtility::getKartVel(mKartNum, &local_f8);
+            if (local_f8.dot(local_d4) >= 0.0f) {
+                limitY = local_f8.squared();
+                local_f8.normalize();
+                
+                local_104.sub(mPos, _22c);
+                limitY = local_104.squared();
+                local_104.normalize();
+                local_d4.add(local_f8, local_104);
+                local_d4.negate();
+            } else {
+                mRotMtx.getZDirInline(local_d4);
+            }
+        }
+    } else {
+        local_d4.sub(_22c, mPos);
+    }
+
+    local_d4.y = 0.0f;
+    local_d4.normalize();
+
+    static JGeometry::TVec3f zAxis(0.0f, 0.0f, 1.0f);
+    static JGeometry::TVec3f yAxis(0.0f, 1.0f, 0.0f);
+
+    if (zAxis.dot(local_d4) < -0.9999f) {
+        f32 s = sinf(JGeometry::TUtilf::PI());
+        f32 c = cosf(JGeometry::TUtilf::PI());
+        mRotMtx[1][1] = 1.0f;
+        mRotMtx[0][0] = c;
+        mRotMtx[0][2] = s;
+        mRotMtx[2][0] = -s;
+        mRotMtx[2][2] = c;
+        mRotMtx[2][1] = 0.0f;
+        mRotMtx[1][2] = 0.0f;
+        mRotMtx[1][0] = 0.0f;
+        mRotMtx[0][1] = 0.0f;
+    } else {
+        mRotMtx.setRotate(zAxis, local_d4);
+    }
+
+    if (mJugemItem != nullptr) {
+        mJugemItem->setRMtx(mRotMtx);
+    }
+    GeographyObj::moveShadowModel();
+}
+
+bool TJugem::checkKartCrash() {
+    bool kartHasCrashed = false;
+
+    if ((KartCtrl::getKartCtrl()->getKartBody(mKartNum)->
+        mCarStatus & 0x0000280001980000uLL) != 0
+    ) {
+        kartHasCrashed = true;
+    }
+
+    return kartHasCrashed;
+}
+
+void TJugem::setPosition(const JGeometry::TVec3f &newPos) {
+    if (getState() == 7) {
+        setState(8);
+    }
+
+    mPos.set(newPos);
+    if (mJugemItem != nullptr) {
+        mJugemItem->setPosition(newPos);
+    }
+}
+
+void TJugem::setRMtx(const JGeometry::TPos3f &rotMtx) {
+    if (getState() == 7) {
+        resetAllPosAndMtx();
+        setState(8);
+    }
+
+    mRotMtx.set(rotMtx.mMtx);
+
+    if (mJugemItem != nullptr) {
+        mJugemItem->setRMtx(rotMtx);
+    }
+}
+
+void TJugem::resetAllPosAndMtx() {
+    mPos.zero();
+    PSMTXIdentity(mRotMtx);
+    if (mJugemItem != nullptr) {
+        mJugemItem->setPosition(mPos);
+        mJugemItem->setRMtx(mRotMtx);
+    }
+}
+
+
+void TJugem::localMove(JGeometry::TVec3f *vec) {
+    const f32 half = 0.5f;
+    f32 someX = _208.x;
+    f32 someY = _208.y;
+    f32 someZ = _208.z;
+
+    if ((getGlobalState() == 1) && !mIsStartPoint) {
+        someX *= -1.0f;
+    }
+
+    static JGeometry::TQuat4f qtAxisY;
+    // FIX: Is some init code missing from the quaternion implementation?
+    // static s8 init;
+    // if (!init) {
+    //     init = 1;
+    // }
+
+    f32 dx = vec->x - _22c.x;
+    f32 dz = vec->z - _22c.z;
+
+    f32 theta = atan2f(dx, dz) * half;    
+    f32 s = sinf(theta);
+    f32 c = cosf(theta);
+
+    qtAxisY.set(0.0f, s, 0.0f, c);
+
+    JGeometry::TVec3f local;
+    local.set(someX, someY, someZ);
+
+    JGeometry::TVec3f rotated;
+    qtAxisY.transform(local, rotated);
+
+    vec->add(rotated);
+}
+
+void TJugem::globalMove(JGeometry::TVec3f *param_1) {
+    param_1->add(_22c);
+}
+
+int TJugem::getGlobalState() {
+    int globalState = 0;
+    switch (getState()) {
+        case 0:
+        case 1:
+            globalState = 0;
+            break;
+        case 2:
+        case 3:
+        case 4:
+            globalState = 1;
+            break;
+        case 5:
+        case 6:
+            globalState = 2;
+            break;
+        case 7:
+        case 8:
+            globalState = 3;
+            break;
+        case 9:
+            globalState = 4;
+            break;
+        case 10:
+        case 0xb:
+        case 0xc:
+        case 0xd:
+        case 0xe:
+        case 0xf:
+        case 0x10:
+            globalState = 5;
+            break;
+        case 0x11:
+        case 0x12:
+        case 0x13:
+        case 0x14:
+        case 0x15:
+            globalState = 6;
+            break;
+        case 0x16:
+            globalState = 7;
+            break;
+        }
+    return globalState;
+}
+
+void TJugem::fixPosition(JGeometry::TVec3f* pos, f32 limitY) {
+    if (getGlobalState() == 5 || (GetKartCtrl()->getKartBody(getKartNum())->mCarStatus) & 0x100000000ull) {
+        return;
+    }
+    
+
+    Course *course = RaceMgr::sRaceManager->getCourse();
+    CrsGround crsGround(course);
+
+    // Is this actually used for anything?
+    JGeometry::TVec3f tempPos = mPos;
+
+    setLimitation(pos, limitY, 15.0f);
+
+    f32 groundY = fixGround(crsGround, *pos);
+    fixWall(crsGround, pos);
+    fixNear(pos);
+
+    if (pos->y < groundY) {
+        pos->y = groundY;
+    }
+
+    JGeometry::TVec3f test;
+    test.sub(*pos, mPos);
+
+    if (test.squared() < 1.0f) {
+        pos->set(mPos);
+    }
+    return;
+}
+
+f32 TJugem::fixGround(CrsGround &crsGround, const JGeometry::TVec3f &param_2) {
+    JGeometry::TVec3f local_3c;
+    local_3c = param_2;
+    crsGround.search(_22c);
+
+    JGeometry::TVec3f crsGroundNormal;
+    crsGround.getNormal(&crsGroundNormal);
+
+    crsGroundNormal.squaredZX();
+    crsGroundNormal.normalize();
+    f32 fVar1 = JGeometry::TUtilf::sqrt(crsGroundNormal.squaredZX());
+
+    f32 fVar4 = param_2.y;
+    local_3c.y += scJugemDistance * fVar1;
+
+    crsGround.exceptValley(1);
+    crsGround.search(local_3c);
+    crsGround.exceptValley(0);
+
+    f32 crsGroundHeight = crsGround.getHeight();
+    if ((fVar4 - crsGroundHeight) < 80.0f) {
+        fVar4 = crsGroundHeight + 80.0f;
+    }
+    return fVar4;
+}
+
+// TODO: Fix Registers (code otherwise 100% match.)
+void TJugem::fixWall(CrsGround &crsGround, JGeometry::TVec3f *pos) {
+    JGeometry::TVec3f dir;
+    dir.sub(_22c, *pos);
+
+    const f32 step = 80.0f;
+    const f32 stepHalf = 40.0f;
+
+    int steps = dir.normalize() / step;
+    dir.scale(step);
+
+    if (steps > 0x14) {
+        steps = 0x14;
+    }
+
+    f32 heightStep = 0.0f;
+    if (steps > 0) {
+        heightStep = ((pos->y + 100.0f) - _22c.y) / steps;
+    }
+
+    JGeometry::TVec3f cur;
+    JGeometry::TVec3f next;
+
+    for (s32 i = steps; i >= 0; i--) {
+        JMAVECScaleAdd(&dir, pos, &cur, i);
+        cur.y  = heightStep * (steps - i) + _22c.y;
+
+        JMAVECScaleAdd(&dir, pos, &next, i + 1);
+        next.y = heightStep * (steps - i - 1) + _22c.y;
+
+        crsGround.search(cur);
+        f32 minY = crsGround.getHeight() + stepHalf + step;
+        if (cur.y < minY) {
+            cur.y = minY;
+        }
+
+        crsGround.search(cur, next, step, false);
+
+        cur.y = pos->y;
+
+        int attr = crsGround.getAttribute();
+        if (attr != CrsGround::Attr_2 && attr != CrsGround::Attr_18) {
+            continue;
+        }
+        
+        JGeometry::TVec3f normal;
+
+        f32 strength = crsGround.getWallNormal(&normal, nullptr);
+        if (strength > 0.1f) {
+            if (strength > 1600.0f) {
+                strength = 1600.0f;
+            }
+
+            JGeometry::TVec3f dirNorm(dir);
+            dirNorm.normalize();
+
+            f32 dot = dirNorm.dot(normal);
+            if (dot != 0.0f) {
+                dirNorm.scale(strength / dot);
+            } else {
+                dirNorm.zero();
+            }
+
+            dirNorm.y = 0.0f;
+            pos->add(cur, dirNorm);
+            break;
+        }
+    }
+}
+
+void TJugem::fixNear(JGeometry::TVec3f *param_1) {
+    JGeometry::TVec3f distanceDiff;
+    distanceDiff.sub(*param_1, _22c);
+
+    f32 distSq = distanceDiff.squaredZX();
+    f32 normalRange = SiUtil::getNormalRange(distSq, 10000.0f, 160000.0f);
+
+    f32 newY;
+    if ((1.0f - normalRange) > 0.0f) {
+        newY = ((1.0f - normalRange) * 350.0f + _22c.y);
+    }
+    if (param_1->y < newY) {
+        param_1->y = newY;
+    }
+}
+
+void TJugem::setLimitation(JGeometry::TVec3f *param_1, f32 param_2, f32 param_3) {
+    JGeometry::TVec3f kartVel;
+    ObjUtility::getKartVel(mKartNum, &kartVel);
+
+    f32 kartVelMag = PSVECMag(&kartVel);
+
+    JGeometry::TVec3f local_70;
+    local_70.sub(*param_1, mPos);
+
+    if (param_2 > 0.0f) {
+        f32 maxLen = kartVelMag + param_2;
+        f32 yPosDiff = local_70.y;
+
+        JGeometry::TVec3f local_7c;
+        local_7c = local_70;
+        local_7c.y = 0.0f;
+
+        if (PSVECMag(&local_7c) > maxLen) {
+            local_7c.setLength(maxLen);
+            local_7c.y = yPosDiff;
+            param_1->add(mPos, local_7c);
+        }
+    }
+
+    local_70.sub(*param_1, mPos);
+
+    JGeometry::TVec3f splineInterp;
+    mSplineInterp.getVel(&splineInterp);
+
+    f32 fVar1 = (kartVel.y + splineInterp.y) - param_3;
+    f32 fVar2 = param_3 + (kartVel.y + splineInterp.y);
+
+    if (local_70.y < fVar1) {
+        param_1->y = mPos.y + fVar1;
+    } else if (local_70.y > fVar2) {
+        param_1->y = mPos.y + fVar2;
+    }
+}
+
+void TJugem::chase(int param_1, const JGeometry::TVec3f &param_2, const JGeometry::TVec3f &param_3, JGeometry::TVec3f &param_4) {
+    f32 vecMag;
+    JGeometry::TPos3f local_60;
+    JGeometry::TVec3f local_6c;
+    JGeometry::TVec3f local_78;
+    
+    if (!param_2.equals(param_3)) {
+        local_6c.sub(param_2, param_3);
+        vecMag = PSVECMag(&local_6c);
+        if (vecMag > (sChaseDistance ^ 0x80000000)) {
+            local_6c.setLength(sChaseAccel);
+            local_6c.y *= 1.5f;
+            _220.add(local_6c);
+            vecMag = PSVECMag(&_220);
+            if (vecMag > 10.0f) {
+                _220.setLength(10.0f);
+            }
+        } else {
+            local_6c.setLength(sChaseDecel);
+            local_6c.y *= 3.0f;
+            if (_220.x * local_6c.x < 0.0f) {
+                _220.x += local_6c.x;
+            }
+            if (_220.y * local_6c.y < 0.0f) {
+                _220.y += local_6c.y;
+            }
+            if (_220.z * local_6c.z < 0.0f) {
+                _220.z += local_6c.z;
+            }
+            vecMag = PSVECMag(&_220);
+            if (vecMag < sChaseEndSpeed) {
+                param_4.set(param_2);
+                _220.zero();
+            }
+        }
+        ObjUtility::getKartVel(param_1,&local_78);
+        mVel.add(local_78, _220);
+        param_4.add(param_3, mVel);
+    }
+}
+
+void TJugemHeadItem::hide() {
+    setObjFlagHidding();
+}
+
+void TJugem::hideAll() {
+    setObjFlagHidding();
+    ShadowModel *shadowModel = getShadowModel();
+    if (shadowModel != nullptr) {
+        shadowModel->clearVisible(mCameraNum);
+    }
+
+    for (s32 i = 0; i < 3; i++) {
+        TJugemItem *tJugemItem = mItem[i];
+        if (tJugemItem != nullptr) {
+            tJugemItem->hideAll();
+        }
+    }
+
+    for (s32 i = 0; i < 2; i++) {
+        TJugemHeadItem *tJugemHeadItem = mHeadItem[i];
+        if (tJugemHeadItem != nullptr) {
+            tJugemHeadItem->hideAll();
+        }
+    }
+}
+
+void TJugem::show(u8 id) {
+    if (mJugemItem != nullptr) {
+        mJugemItem->show(id);
+    }
+
+    if (mJugemHeadItem != nullptr) {
+        mJugemHeadItem->show(id);
+    }
+    
+    clrObjFlagHidding();
+    ShadowModel *shadowModel = mShadowMdl;
+
+    if (shadowModel != nullptr) {
+        shadowModel->setVisible(mCameraNum);
+        getShadowModel()->setAlpha(0xff);
+    }
+}
+
+void TJugemHeadItem::show(u8) {
+    clrObjFlagHidding();
+}
+
+void TJugem::wearCap(u32 id) {
+    if (mJugemHeadItem != nullptr) {
+        mJugemHeadItem->hide();
+    }
+#line 1403
+    JUT_MINMAX_ASSERT(0, id, 2)
+    if (mHeadItem[id] != nullptr) {
+        mJugemHeadItem = mHeadItem[id];
+        mModel._14 = (u32 *)mJugemHeadItem;
+    }
+}
+
+void TJugem::InitExec() {
+    Observer_FindAndInit(TJugem, 23);
+}
+
+void TJugem::MoveExec() {
+    Observer_FindAndExec(TJugem, 23);
+}
+
+void TJugem::changeAnimation(u32 type) {
+    if (isDemoMode()) {
+        #line 1448
+        JUT_MINMAX_ASSERT(0, type, 3);
+        mAnmCtrl = mDemoAnmController[type];
+        mAnmPlayer.init(mDemoAnmController[type], sDemoAnmStateTable[type].tAnmInfo, sDemoAnmStateTable[type].arraySize);
+    } else {
+        #line 1452
+        JUT_MINMAX_ASSERT(0, type, 5);
+        mAnmCtrl = mAnmController[type];
+        mAnmPlayer.init(mAnmController[type], sAnmStateTable[type].tAnmInfo, sAnmStateTable[type].arraySize);
+    }
+    if (mAnmCtrl->IsAvailableTrans()) {
+        mAnmCtrl->StopTrans();
+    }
+
+    if (mJugemItem != nullptr) {
+        mJugemItem->changeAnimation(type);
+    }
+}
+
+bool TJugem::isAbleStart() {
+    return mIsAbleStart;
+}
+
+void TJugem::cutFishLine() {
+    if (getState() != 8) {
+        return;
+    }
+    mAnmPlayer._10 = 1;
+    mAnmPlayer._e |= 1;
+    
+    TJugemItem *tJugemItem = mJugemItem;
+    if (tJugemItem == nullptr) {
+        return;
+    }
+    tJugemItem->mJugemAnmPlayer._10 = 1;
+    tJugemItem->mJugemAnmPlayer._e |= 1;
+    return;
+}
+
+bool TJugem::nodeCallBack(J3DJoint* joint, int param_2) {
+    if (param_2 == false) {
+        // Get joint index
+        u16 jointIndex = joint->mJointIdx;
+
+        // Access global J3D system
+        J3DModel* model = j3dSys._38;
+        J3DModelData* modelData = model->mModelData;
+
+        // FIX: This is almost certainly wrong. Need to work out correct casting.
+        TJugemItem* obj = (TJugemItem *)((ExModel *)model->getUserArea())->_14;
+        if (obj) {
+            Mtx& mtx = model->getAnmMtx(jointIndex);
+
+            JGeometry::TPos3f copy;
+            copy.set(mtx);
+
+            JGeometry::TVec3f pos;
+            pos.set(mtx[0][3], mtx[1][3], mtx[2][3]);
+
+            obj->setPosition(pos);   // vtable + 0x80
+            obj->setRMtx(copy);      // vtable + 0x84
+        }
+    }
+    return true;
+}
+
+void TJugemHeadItem::setPosition(const JGeometry::TVec3f &pos) {
+    mPos.set(pos);
+}
+
+void TJugemHeadItem::setRMtx(const JGeometry::TPos3f &rMtx) {
+    mRotMtx.set(rMtx.mMtx);    
+}
+
+void TJugem::setCameraNum(u8 cam) {
+    #line 1520
+    JUT_ASSERT_MSG(cam < scJugemCameraMax, "cam < scJugemCameraMax");
+    mCameraNum = cam;
+    if (mSignal != nullptr) {
+        mSignal->mKartCamIndex = mCameraNum;
+    }
+}
+
+void TJugem::setKartNum(u8 kart) {
+    #line 1530
+    u8 scJugemKartMax = 8;
+    JUT_ASSERT_MSG(kart < scJugemKartMax, "kart < scJugemKartMax");
+    mKartNum = kart;
+}
+
+u32 TJugem::getScreenType() {
+    s32 consoleNum = RaceMgr::getCurrentManager()->getConsoleNumber();
+    s32 screenType = 0;
+
+    #line 1711
+    JUT_ASSERT_MSG(consoleNum > 0, "consoleNum > 0");
+
+    // TODO: See if this can become an enum.
+    switch (consoleNum) {
+        case 1:
+            screenType = 0;
+            break;
+        case 2:
+            screenType = 1;
+            break;
+        case 3:
+        case 4:
+            screenType = 2;
+            break;
+        default:
+            #line 1725
+            JUT_ASSERT_MSG(false, "false");
+            break;
+    }
+    return screenType;
+}

--- a/src/Shiraiwa/JugemRescue.cpp
+++ b/src/Shiraiwa/JugemRescue.cpp
@@ -1,0 +1,44 @@
+#include "Kaneshige/RaceMgr.h"
+#include "Shiraiwa/JugemMain.h"
+#include "Yamamoto/kartCtrl.h"
+
+void TJugem::initFunc_RescueWait() {}
+
+void TJugem::doFunc_RescueWait() {
+    if ((GetKartCtrl()->getKartBody(getKartNum())->mCarStatus & 0x400000ull) == 0) {
+        setState(8);
+    }
+}
+
+void TJugem::initFunc_Rescue() {
+    mSplineInterp.stop();
+    wearCap(1);
+    hold(1, 0);
+    changeAnimation(2);
+    show(0);
+}
+
+void TJugem::doFunc_Rescue() {
+    GeographyObj::moveShadowModel();
+    if (checkRescueOutProc()) {
+        if (RaceMgr::getCurrentManager()->getKartChecker(getKartNum())->isGoal()) {
+            setState(9);
+        } else {
+            setState(0);
+        }
+    }
+}
+
+bool TJugem::checkRescueInProc() {
+    switch (getGlobalState()) {
+        case 3:
+        case 6:
+        case 7:
+            return false;
+    }
+    return ((GetKartCtrl()->getKartBody(mKartNum)->mCarStatus & 0x400000) != 0) ? true : false;
+}
+
+bool TJugem::checkRescueOutProc() {
+    return (getGlobalState() == 6) || ((GetKartCtrl()->getKartBody(getKartNum())->mCarStatus & 0x400000ull) == 0);
+}

--- a/src/Shiraiwa/JugemRescue.cpp
+++ b/src/Shiraiwa/JugemRescue.cpp
@@ -1,3 +1,4 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Kaneshige/RaceMgr.h"
 #include "Shiraiwa/JugemMain.h"
 #include "Yamamoto/kartCtrl.h"

--- a/src/Shiraiwa/JugemReverse.cpp
+++ b/src/Shiraiwa/JugemReverse.cpp
@@ -1,3 +1,4 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Inagaki/GameAudioMain.h"
 #include "Kaneshige/RaceMgr.h"
 #include "Shiraiwa/JugemMain.h"

--- a/src/Shiraiwa/JugemReverse.cpp
+++ b/src/Shiraiwa/JugemReverse.cpp
@@ -1,0 +1,109 @@
+#include "Inagaki/GameAudioMain.h"
+#include "Kaneshige/RaceMgr.h"
+#include "Shiraiwa/JugemMain.h"
+
+Vec TJugem::scReversePoints0_1p[5] = {
+    { -400.0f,   0.0f, -1050.0f },
+    { -300.0f,  50.0f,  -250.0f },
+    {  -50.0f,  50.0f,  -150.0f },
+    {  -25.0f,  50.0f,  -150.0f },
+    {    0.0f,  50.0f,  -350.0f }
+};
+
+Vec TJugem::scReversePoints0_multi[5] = {
+    { -400.0f,   0.0f, -1050.0f },
+    { -300.0f, 100.0f,  -250.0f },
+    {  -50.0f, 100.0f,  -150.0f },
+    {  -25.0f, 100.0f,  -150.0f },
+    {    0.0f,  90.0f,  -250.0f }
+};
+
+const Vec TJugem::scReversePoints1_multi[6] = {
+    { 0.0f, 100.0f, -250.0f },
+    { 0.0f,  50.0f, -450.0f },
+    { 0.0f, 120.0f, -250.0f },
+    { 0.0f,  70.0f, -150.0f },
+    { 0.0f,  50.0f,  150.0f },
+    { 0.0f,  70.0f,  -50.0f },
+};
+
+Vec TJugem::scReversePoints2[4] = {
+    { 0.0f,    0.0f, 0.0f },
+    { 0.0f,    0.0f, 0.0f },
+    { 0.0f, -450.0f, 0.0f },
+    { 0.0f,    0.0f, 0.0f }
+};
+
+s16 TJugem::scReverseJudgeTime = 90;
+s16 TJugem::scReviveJudgeTime  = 30;
+f32 TJugem::sReverseEnterSpeed = 0.02f;
+f32 TJugem::sReverseStaySpeed  = 0.0099999998f;
+f32 TJugem::sReverseLeaveSpeed = 0.1f;
+
+void TJugem::initFunc_Reverse() {
+    wearCap(1);
+    hold(1, 4);
+    show(0);
+    changeAnimation(3);
+    switch (getScreenType()) {
+        case 0:
+            mSplineInterp.setPoint(5, &scReversePoints0_1p->x, sReverseEnterSpeed, false);
+            break;
+        case 1:
+        case 2:
+            mSplineInterp.setPoint(5, &scReversePoints0_multi->x, sReverseEnterSpeed, false);
+            break;
+        default:
+            break;
+    }
+    _278 = 0;
+    _276 = 0;
+    resetJugemOriginNumber();
+}
+
+void TJugem::doFunc_Reverse() {
+    move(getKartNum());
+    GetGameAudioMain()->startKartSystemSe(getKartNum(), 0x1000a);
+    if (!mSplineInterp.checkUnknownBool13()) {
+        switch (getScreenType()) {
+            case 0:
+                break;
+            case 1:
+            case 2:
+                mSplineInterp.setPoint(6, &scReversePoints1_multi->x, sReverseStaySpeed, true);
+                break;
+        }
+    }
+    if (checkReviveProc() != false) {
+        setState(6);
+    }
+}
+
+void TJugem::initFunc_RevEnd() {
+    mSplineInterp.setPointOffset(4, &scReversePoints2->x, sReverseLeaveSpeed, false);
+}
+
+void TJugem::doFunc_RevEnd() {
+    move(getKartNum());
+    if (mSplineInterp.checkUnknownBool13() == false) {
+        setState(1);
+    }
+}
+
+bool TJugem::checkReverseProc() {
+    if (RaceMgr::getCurrentManager()->getKartChecker(getKartNum())->isReverse()) {
+        _276++;
+    } else {
+        _276 = 0;
+    }
+    return (_276 > scReverseJudgeTime);
+}
+
+bool TJugem::checkReviveProc() {
+    if (!RaceMgr::getCurrentManager()->getKartChecker(getKartNum())->isReverse()) {
+        _278++;
+    } else {
+        _278 = 0;
+    }
+    return (_278 > scReviveJudgeTime);
+}

--- a/src/Shiraiwa/JugemRodBoard.cpp
+++ b/src/Shiraiwa/JugemRodBoard.cpp
@@ -1,0 +1,176 @@
+#include "JSystem/JKernel/JKRHeap.h"
+#include "JSystem/JUtility/JUTAssert.h"
+#include "Sato/ObjUtility.h"
+#include "Shiraiwa/JugemRodItem.h"
+#include "Shiraiwa/SiUtil.h"
+
+
+J3DAnmTexPattern *TJugemRodBoard::sJugemRodBoardBtpAnm;
+const f32 TJugemRodBoard::scObjScale[4] = { 1.0f, 1.3f, 1.6f, 1.6f };
+
+TJugemRodBoard::TJugemRodBoard() : TJugemRodItem(0x104) {
+    NewAnmCtrl();
+    reset();
+    setObjFlagNorm();
+}
+
+TJugemRodBoard::~TJugemRodBoard() {}
+
+void TJugemRodBoard::reset() {
+    GeographyObj::resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    _164.resetFrame();
+    int console = (SiUtil::getConsoleNum() & 0xFF) - 1;
+#line 62
+    JUT_MINMAX_ASSERT(0, console, 4);
+    f32 objScale = scObjScale[console];
+    mScale.setAll(objScale);
+}
+
+void TJugemRodBoard::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    void *ptrMainArc = ObjUtility::getPtrMainArc("/Objects/board01.btp");
+    J3DAnmObjMaterial::setupTexPatternAnmData(&sJugemRodBoardBtpAnm, modelData, ptrMainArc);
+}
+
+const char *TJugemRodBoard::getBmdFileName() {
+    return "/Jugem/jg_board01.bmd";
+}
+
+void TJugemRodBoard::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createDifferedModel(jkrSolidHeap, param_2, 0x80000, 0);
+    _164.setExModel(&mModel);
+    _164.setAnmBase(sJugemRodBoardBtpAnm);
+    _164.initFrameCtrl(_164.getAnmBase());
+}
+
+void TJugemRodBoard::show(u8 param_1) {
+    _164.setFrame(param_1);
+    clrObjFlagHidding();
+}
+
+void TJugemRodBoard::update() {
+    _164.anmFrameProc();
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+
+J3DAnmTevRegKey *TJugemRodBoard2::sJugemRodBoard2BrkAnm;
+const f32 TJugemRodBoard2::scObjScale[4] = { 1.1f, 1.4f, 1.4f, 1.4f };
+
+TJugemRodBoard2::TJugemRodBoard2() : TJugemRodItem(0x105) {
+    reset();
+    setObjFlagNorm();  
+}
+
+TJugemRodBoard2::~TJugemRodBoard2() {}
+
+void TJugemRodBoard2::reset() {
+    GeographyObj::resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    _164.resetFrame();
+    int console = (SiUtil::getConsoleNum() & 0xFF) - 1;
+#line 171
+    JUT_MINMAX_ASSERT(0, console, 4);
+    f32 objScale = scObjScale[console];
+    mScale.setAll(objScale);
+}
+
+void TJugemRodBoard2::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    void *ptrMainArc = ObjUtility::getPtrMainArc("/Objects/BoardFinalLap.brk");
+    J3DAnmObjMaterial::setupTevRegAnmData(&sJugemRodBoard2BrkAnm, modelData, ptrMainArc);
+}
+
+const char *TJugemRodBoard2::getBmdFileName() {
+    return "/Jugem/BoardFinalLap.bmd";
+}
+
+void TJugemRodBoard2::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createDifferedModel(jkrSolidHeap, param_2, 0x1000000, 0);
+    _164.setExModel(&mModel);
+    _164.setAnmBase(sJugemRodBoard2BrkAnm);
+    _164.initFrameCtrl(_164.getAnmBase());
+}
+
+void TJugemRodBoard2::show(u8) {
+    clrObjFlagHidding();
+}
+
+void TJugemRodBoard2::update() {
+    _164.anmFrameProc();
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+J3DAnmTevRegKey *TJugemRodBoardRev::sJugemRodBoardRevBrkAnm;
+const f32 TJugemRodBoardRev::scObjScale[4] = { 1.0f, 1.3f, 1.4f, 1.4f };
+
+TJugemRodBoardRev::TJugemRodBoardRev() : TJugemRodItem(0x106) {
+    reset();
+    setObjFlagNorm();
+}
+
+TJugemRodBoardRev::~TJugemRodBoardRev() {}
+
+void TJugemRodBoardRev::reset() {
+    GeographyObj::resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    _164.resetFrame();
+    int console = (SiUtil::getConsoleNum() & 0xFF) - 1;
+#line 277
+    JUT_MINMAX_ASSERT(0, console, 4);
+    f32 objScale = scObjScale[console];
+    mScale.setAll(objScale);
+}
+
+void TJugemRodBoardRev::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    void *ptrMainArc = ObjUtility::getPtrMainArc("/Objects/BoardReverse.brk");
+    J3DAnmObjMaterial::setupTevRegAnmData(&sJugemRodBoardRevBrkAnm, modelData, ptrMainArc);
+}
+
+const char *TJugemRodBoardRev::getBmdFileName() {
+    return "/Objects/BoardReverse.bmd";
+}
+
+void TJugemRodBoardRev::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createDifferedModel(jkrSolidHeap, param_2, 0x1000000, 0);
+    _164.setExModel(&mModel);
+    _164.setAnmBase(sJugemRodBoardRevBrkAnm);
+    _164.initFrameCtrl(_164.getAnmBase());
+}
+
+void TJugemRodBoardRev::show(u8 param_1) {
+    _164.setFrame(param_1);
+    clrObjFlagHidding();
+}
+
+void TJugemRodBoardRev::update() {
+    _164.anmFrameProc();
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+void TJugemRodBoardRev::calc() {
+    _164.update();
+}
+
+void TJugemRodBoard2::calc() {
+    _164.update();
+}
+
+void TJugemRodBoard::calc() {}

--- a/src/Shiraiwa/JugemRodBoard.cpp
+++ b/src/Shiraiwa/JugemRodBoard.cpp
@@ -1,3 +1,4 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "Sato/ObjUtility.h"

--- a/src/Shiraiwa/JugemRodSignal.cpp
+++ b/src/Shiraiwa/JugemRodSignal.cpp
@@ -1,0 +1,423 @@
+#include "Inagaki/GameAudioMain.h"
+#include "JSystem/J3D/J3DJoint.h"
+#include "JSystem/J3D/J3DSys.h"
+#include "JSystem/JGeometry/Matrix.h"
+#include "JSystem/JGeometry/Vec.h"
+#include "JSystem/JKernel/JKRHeap.h"
+#include "JSystem/JParticle/JPAMath.h"
+#include "JSystem/JUtility/JUTAssert.h"
+#include "JSystem/JUtility/JUTNameTab.h"
+#include "Kaneshige/ExModel.h"
+#include "Kaneshige/Movie/MovieApp.h"
+#include "Osako/ResMgr.h"
+#include "Sato/AnmController.h"
+#include "Sato/J3DAnmObject.h"
+#include "Sato/JPEffectMgr.h"
+#include "Sato/JPEffectPerformer.h"
+#include "Sato/ObjUtility.h"
+#include "Shiraiwa/AnmPlayer.h"
+#include "Shiraiwa/JugemMain.h"
+#include "Shiraiwa/JugemRodItem.h"
+#include "Yamamoto/kartCamera.h"
+#include "Yamamoto/kartCtrl.h"
+#include "dolphin/mtx.h"
+#include "types.h"
+
+J3DAnmTevRegKey *TJugemRodSignal::sJugemRodSignalBrkAnm;
+const char *TJugemRodSignal::scRedParticleName = "mk_jg_signalR";
+const char *TJugemRodSignal::scGreenParticleName = "mk_jg_signalB";
+s16 TJugemRodSignal::sRandomWait;
+int TJugemRodSignal::sLeftJointNo;
+int TJugemRodSignal::sMiddleJointNo;
+int TJugemRodSignal::sRightJointNo;
+const u8 TJugemRodSignal::scSignalInterval = 0x3c;
+
+
+TJugemRodSignal::TJugemRodSignal() : TJugemRodItem(0x107) {
+    NewAnmCtrl();
+    setObjFlagNorm();
+}
+
+TJugemRodSignal::~TJugemRodSignal() {}
+
+void TJugemRodSignal::reset() {
+    GeographyObj::resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    sRandomWait = 0;
+    mEmitterRight = nullptr;
+    mEmitterMiddle = nullptr;
+    mEmitterLeft = nullptr;
+    _164.resetFrame();
+    _184 = 0;
+    _188 = 0;
+    if (TJugem::isDemoMode()) {
+        mScale.x = 1.0f;
+        mScale.y = 1.0f;
+        mScale.z = 1.0f;
+    } else {
+        mScale.x = 1.5f;
+        mScale.y = 1.5f;
+        mScale.z = 1.5f;
+    }
+}
+
+void TJugemRodSignal::loadAnimation() {
+    void *pvVar1;
+    J3DModelData *test = mModel.getModelData();
+    static char *fileName = "/Objects/jg_signal.brk";
+    if (TJugem::isDemoMode()) {
+        pvVar1 = ResMgr::getPtr(ResMgr::mcArcOpening, fileName);
+    } else {
+        pvVar1 = ObjUtility::getPtrMainArc(fileName);
+    }
+    J3DAnmObjMaterial::setupTevRegAnmData(
+        &sJugemRodSignalBrkAnm, 
+        test,
+        pvVar1
+    );
+}
+
+const char *TJugemRodSignal::getShadowBmdFileName() {
+    return nullptr;
+}
+
+const char *TJugemRodSignal::getBmdFileName() {
+    static const char *cBmdName = "/Objects/jg_signal.bmd";
+    return cBmdName;
+}
+
+void TJugemRodSignal::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createDifferedModel(jkrSolidHeap, param_2, 0x1000000, 0);
+    _164.setExModel(&mModel);
+    _164.setAnmBase(sJugemRodSignalBrkAnm);
+    _164.initFrameCtrl(_164.getAnmBase());
+
+    sLeftJointNo = mModel.getModelData()->getJointName()->getIndex("left");
+    #line 147
+    JUT_ASSERT_MSG(sLeftJointNo != -1, "joint \"left\" is Not Found.");
+
+    sMiddleJointNo = mModel.getModelData()->getJointName()->getIndex("middle");
+    #line 149
+    JUT_ASSERT_MSG(sMiddleJointNo != -1, "joint \"middle\" is Not Found.");
+
+    sRightJointNo = mModel.getModelData()->getJointName()->getIndex("right");
+    #line 151
+    JUT_ASSERT_MSG(sRightJointNo != -1, "joint \"right\" is Not Found.");
+}
+
+void TJugemRodSignal::createColModel(J3DModelData *modelData) {}
+
+void TJugemRodSignal::calc() {
+    if (_184 != false) {
+        bool effectAccepted = isAcceptEffect();
+        _188++;
+        if (_188 == scSignalInterval) {
+            if (effectAccepted) {
+                createEmitter(&mEmitterLeft, sLeftJointNo, scRedParticleName);
+            }
+            show(1);
+            GetGameAudioMain()->startRaceSystemSe(0x20006);
+        } else if (_188 == 0x78) {
+            if (effectAccepted) {
+                createEmitter(&mEmitterMiddle, sMiddleJointNo,scRedParticleName);
+            }
+            show(3);
+            GetGameAudioMain()->startRaceSystemSe(0x20006);
+        } else if (_188 == 0xb4) {
+            if (effectAccepted) {
+                createEmitter(&mEmitterRight, sRightJointNo, scRedParticleName);
+            }
+            show(5);
+            GetGameAudioMain()->startRaceSystemSe(0x20006);
+        } else if (_188 == sRandomWait + 0xf0) {
+            if (effectAccepted) {
+                createEmitter(&mEmitterLeft, sLeftJointNo,  scGreenParticleName);
+                createEmitter(&mEmitterMiddle, sMiddleJointNo,scGreenParticleName);
+                createEmitter(&mEmitterRight, sRightJointNo, scGreenParticleName);
+            }
+            show(7);
+            GetGameAudioMain()->startRaceSystemSe(0x20007);
+        } else if (_188 > sRandomWait + 300) {
+            _184 = false;
+        }
+    }
+}
+
+void TJugemRodSignal::createEmitter(JPABaseEmitter **emitter, s32 index, const char *effectName) {
+    Mtx &mtx = mModel.getModel()->getAnmMtx(index);
+    JGeometry::TVec3f pos(mtx[0][3], mtx[1][3], mtx[2][3]);
+    *emitter = JPEffectMgr::getEffectMgr()->createEmtCam(effectName, pos, mKartCamIndex);
+    
+    JGeometry::TVec3f stackScale = mScale;
+    (*emitter)->setGlobalScale(stackScale);
+}
+
+void TJugemRodSignal::startCountDown() {
+    _188 = 0;
+    _184 = 1;
+}
+
+void TJugemRodSignal::show(u8 param_1) {
+    _164.setFrame(param_1);
+    clrObjFlagHidding();
+}
+
+
+// FIX: Try and remove GOTOs.
+void TJugemRodSignal::update() {
+    _164.anmFrameProc();
+    setModelMatrixAndScale();
+    mModel.update(0);
+
+    if (!_184) return;
+    if (!isAcceptEffect()) return;
+
+    bool bVar1;
+
+    // Left Emitter
+    JPABaseEmitter* emitter = mEmitterLeft;
+    int jointNumber = sLeftJointNo;
+    if (emitter != nullptr) {
+        bVar1 = false;
+        if (emitter->checkStatus(0x8) != 0 &&
+            (emitter->mAlivePtclBase.getNum() + emitter->mAlivePtclChld.getNum() == 0)) {
+            bVar1 = true;
+        }
+
+        if (!bVar1) {
+            JPASetRMtxTVecfromMtx(mModel.getModel()->getAnmMtx(jointNumber), emitter->mGlobalRot, &emitter->mGlobalTrs);
+            goto end_left; // Match assembly jump behavior
+        }
+    }
+    mEmitterLeft = nullptr;
+    end_left:;
+
+    // Middle Emitter
+    emitter = mEmitterMiddle;
+    jointNumber = sMiddleJointNo;
+    if (emitter != nullptr) {
+        bVar1 = false;
+        if (emitter->checkStatus(0x8) != 0 &&
+            (emitter->mAlivePtclBase.getNum() + emitter->mAlivePtclChld.getNum() == 0)) {
+            bVar1 = true;
+        }
+
+        if (!bVar1) {
+            JPASetRMtxTVecfromMtx(mModel.getModel()->getAnmMtx(jointNumber), emitter->mGlobalRot, &emitter->mGlobalTrs);
+            goto end_mid;
+        }
+    }
+    mEmitterMiddle = nullptr;
+    end_mid:;
+
+    // Right Emitter
+    emitter = mEmitterRight;
+    jointNumber = sRightJointNo;
+    if (emitter != nullptr) {
+        bVar1 = false;
+        if (emitter->checkStatus(0x8) != 0 &&
+            (emitter->mAlivePtclBase.getNum() + emitter->mAlivePtclChld.getNum() == 0)) {
+            bVar1 = true;
+        }
+
+        if (!bVar1) {
+            JPASetRMtxTVecfromMtx(mModel.getModel()->getAnmMtx(jointNumber), emitter->mGlobalRot, &emitter->mGlobalTrs);
+            goto end_right;
+        }
+    }
+    mEmitterRight = nullptr;
+    end_right:;
+}
+
+bool TJugemRodSignal::isAcceptEffect() {
+    switch (GetKartCtrl()->getKartCam(mKartCamIndex)->GetCameraMode()) {
+        case 2:
+            return false;
+        default:
+            return true;
+    }
+}
+
+
+
+
+TAnmInfo TJugemRodPukuPuku::sAnmInfos_Puku_Demo2[3] = {
+    {"/Objects/jg_puku_in_b.bck", nullptr, nullptr, 0, 0, 1, 1, 0},
+    {"/Objects/jg_puku_wait_b.bck", nullptr, nullptr, 2, 0, 0, 2, 0},
+    {"/Objects/jg_puku_out_b.bck", nullptr, nullptr, 0, 0, 1, 0xFF, 0},
+};
+
+TAnmInfo TJugemRodPukuPuku::sAnmInfos_Puku_Demo3[1] = {
+    { "/Objects/jg_puku_in_c.bck", nullptr, nullptr, 0, 0, 1, 0xFF, 0 }
+};
+
+TJugemAnmTableEntry TJugemRodPukuPuku::sDemoAnmStateTable[3] = {
+    { nullptr, 0 },
+    { sAnmInfos_Puku_Demo2, 3 },
+    { sAnmInfos_Puku_Demo3, 1 }
+};
+
+
+TJugemRodPukuPuku::TJugemRodPukuPuku() : TJugemRodItem(0x108) {
+    for (int i = 0; i < 3; i++) {
+        mAnmController[i] = new AnmController();
+        if (sDemoAnmStateTable[i].tAnmInfo != nullptr) {
+            TAnmPlayer::resetAnimations(sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize);
+        }
+    }
+}
+
+TJugemRodPukuPuku::~TJugemRodPukuPuku() {
+    for (s32 i = 0; i < 3; i++) {
+        delete mAnmController[i];
+    }
+}
+
+void TJugemRodPukuPuku::reset() {
+    GeographyObj::resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    //_164.getFrameCtrl()->setAttribute(0);
+    _170 = 0;
+    //_164.getFrameCtrl()->mState = 0;
+    _171 = 0;
+}
+
+void TJugemRodPukuPuku::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    for (int i = 0; i < 3; i++) {
+        if (sDemoAnmStateTable[i].tAnmInfo != nullptr) {
+            TAnmPlayer::loadAnimations(sDemoAnmStateTable[i].tAnmInfo,
+                sDemoAnmStateTable[i].arraySize, modelData, ResMgr::mcArcOpening
+            );
+        }
+    }
+
+    for (u16 i = 0; i < modelData->getShapeNum(); i++) {
+        modelData->getShapeNodePointer(i)->setTexMtxLoadType(0x2000);
+    }
+}
+
+void TJugemRodPukuPuku::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createDifferedModel(jkrSolidHeap, param_2, 0x200, 1);
+
+    u16 idx = mModel.getModelData()->getJointName()->getIndex("puku_root");
+    J3DJoint *joint = mModel.getModelData()->getJointNodePointer(idx);
+    joint->setCallBack(nodeCallBack);
+    mModel._14 = nullptr;
+
+    for (int i = 0; i < 3; i++) {
+        if (sDemoAnmStateTable[i].tAnmInfo != nullptr) {
+            TAnmPlayer::registAnimations(
+                mAnmController[i],
+                &mModel,
+                sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize
+            );
+        }
+    }
+}
+
+void TJugemRodPukuPuku::show(u8 idx) {
+    #line 450
+    JUT_MINMAX_ASSERT(0, idx, 3);
+    if (idx != 0) {
+        mAnmCtrl = mAnmController[idx];
+        mAnmPlayer.init(mAnmController[idx],
+            sDemoAnmStateTable[idx].tAnmInfo,
+            sDemoAnmStateTable[idx].arraySize
+        );
+    }
+    _171 = idx;
+    clrObjFlagHidding();
+}
+
+void TJugemRodPukuPuku::update() {
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+void TJugemRodPukuPuku::calc() {
+    AnmControlTrans *trans;
+    
+    mAnmPlayer.update();
+    if (mAnmPlayer._10 == 0) {
+        setObjFlagHidding();
+    }
+    switch (_171) {
+        case 2:
+            u8 anm_no = mAnmPlayer.getCurAnmNumber();
+            if (mAnmPlayer.mController->getFrameCtrl(anm_no)->getFrame() < 151.0f) {
+                GetGameAudioMain()->startSystemSe(0x20068);
+            } else if (_170 == 0) {
+                GetGameAudioMain()->startSystemSe(0x20069);
+                _170 = 1;
+            }
+        break;
+    }
+}
+
+void TJugemRodPukuPuku::setPosition(const JGeometry::TVec3f &newPos) {
+    switch (_171) {
+        case 2:
+            if (_170 != 0) {
+                return;
+            }
+            mPos.set(newPos);
+            return;
+    }
+    
+    mPos.set(newPos);
+}
+
+void TJugemRodPukuPuku::setRMtx(const JGeometry::TPos3f &newRotMtx) {
+    switch (_171) {
+        case 2:
+            if (_170 != 0) {
+                return;
+            }
+            mRotMtx.set(newRotMtx.mMtx);
+            return;
+    }
+    
+    mRotMtx.set(newRotMtx.mMtx);
+}
+
+void TJugemRodPukuPuku::setCurrentViewNo(u32 viewNo) {
+    mModel.setCurrentViewNo(viewNo);
+    
+    MtxPtr effectMtx = MovieApp::getMovieApp()->getMdlViewer()->getChaseLight()->getEffectMtx();
+    mModel.setEffectMtx(effectMtx, 1);
+}
+
+bool TJugemRodPukuPuku::nodeCallBack(J3DJoint* joint, int timing) {
+    if (timing == 0) {
+        int idx = joint->getJntNo();
+
+        J3DModel *model = j3dSys._38;
+        // FIX: This is almost certainly wrong. Need to work out correct casting.
+        TJugemRodItem *tJugemRod = (TJugemRodItem *)((ExModel*)model->getUserArea())->_14;
+        
+        if (tJugemRod != nullptr) {
+            MtxPtr calc_mtx = model->getAnmMtx(idx);
+
+            // JGeometry::TVec3f test;
+            // test.set(calc_mtx[0][0], calc_mtx[0][1], calc_mtx[0][2]);
+
+            calc_mtx[1][3] = calc_mtx[0][1];
+            calc_mtx[2][3] = calc_mtx[0][2];
+            calc_mtx[3][3] = calc_mtx[0][3];
+
+            model->setAnmMtx(idx, calc_mtx);
+            PSMTXCopy(calc_mtx, J3DSys::mCurrentMtx);
+        }
+    }
+
+    return true;
+}

--- a/src/Shiraiwa/JugemRodSignal.cpp
+++ b/src/Shiraiwa/JugemRodSignal.cpp
@@ -1,6 +1,7 @@
 #include "Inagaki/GameAudioMain.h"
 #include "JSystem/J3D/J3DJoint.h"
 #include "JSystem/J3D/J3DSys.h"
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "JSystem/JGeometry/Matrix.h"
 #include "JSystem/JGeometry/Vec.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/Shiraiwa/JugemStart.cpp
+++ b/src/Shiraiwa/JugemStart.cpp
@@ -1,0 +1,174 @@
+#include "Kaneshige/RaceMgr.h"
+#include "Shiraiwa/JugemMain.h"
+#include "Shiraiwa/JugemRodItem.h"
+#include "Yamamoto/kartCtrl.h"
+
+Vec TJugem::scStartPoints0_1p[6] = {
+    { 0.0f, 375.0f, -350.0f },
+    { 0.0f,  75.0f, -350.0f },
+    { 0.0f, 175.0f, -350.0f },
+    { 0.0f,   0.0f, -350.0f },
+    { 0.0f,   0.0f, -350.0f },
+    { 0.0f,   0.0f, -350.0f },
+};
+
+Vec TJugem::scStartPoints0_2p[5] = {
+    { 300.0f, 240.0f, -400.0f },
+    { 300.0f, -60.0f, -400.0f },
+    { 300.0f,  40.0f, -400.0f },
+    { 300.0f, 240.0f, -400.0f },
+    { 300.0f,   0.0f, -400.0f },
+};
+
+s16 TJugem::sStartWaitCameraFrame;
+s16 TJugem::sStartWaitBlendFrame;
+f32 TJugem::sStartDownSpeed = 0.008f;
+f32 TJugem::sStartUpSpeed = 0.12f;
+s16 TJugem::sStartUpFrame = 10;
+
+void TJugem::resetStartPosition() {
+    switch (getScreenType()) {
+        case 0:
+            mSplineInterp.setPoint(6, &scStartPoints0_1p->x, sStartDownSpeed, false);
+            break;
+        case 1:
+        case 2:
+            mSplineInterp.setPoint(5, &scStartPoints0_2p->x, sStartDownSpeed, false);
+            break;
+        default:
+            break;
+    }
+    
+    mSplineInterp.update();
+    mSplineInterp.stop();
+
+    if (RaceMgr::getCurrentManager()->getRacePhase() == PHASE_CRS_DEMO) {
+        hideAll();
+        setState(10);
+    } else {
+        setState(0xb);
+    }
+
+    changeAnimation(0);
+    resetJugemOriginCourse();
+}
+
+void TJugem::initFunc_StartWaitPermission() {
+    changeAnimation(0);
+}
+
+void TJugem::doFunc_StartWaitPermission() {
+    move(getKartNum());
+    if (GetKartCtrl()->CheckJugemuSignal()) {
+        setState(0xb);
+    }
+}
+
+void TJugem::initFunc_StartWaitCamera() {
+    wearCap(0);
+    hold(1, 2);
+    show(0);
+    changeAnimation(0);
+    mSplineInterp.restart();
+    _274 = 0;
+}
+
+void TJugem::doFunc_StartWaitCamera() {
+    move(getKartNum());
+    if (getStateCount() >= sStartWaitCameraFrame) {
+        setState(0xc);
+    }
+}
+
+void TJugem::initFunc_StartDown() {}
+
+void TJugem::doFunc_StartDown() {
+    move(getKartNum());
+    if (mSplineInterp.getUnknownValue10() + mSplineInterp.getRatio() > 1.3f) {
+        mSplineInterp.stop();
+    }
+    if (mSplineInterp.checkUnknownBool13() == false && mAnmPlayer.getCurAnmNumber() != 0) {
+        setState(0xd);
+    }
+}
+
+void TJugem::initFunc_StartWaitBlend() {}
+
+void TJugem::doFunc_StartWaitBlend() {
+    move(getKartNum());
+    if (getStateCount() > sStartWaitBlendFrame) {
+        setState(0xe);
+    }
+}
+
+void TJugem::initFunc_StartCountDown() {
+    startNextAnime();
+    mSignal->startCountDown();
+}
+
+void TJugem::doFunc_StartCountDown() {
+    move(getKartNum());
+    bool shouldSetState = false;
+    if (mSignal->_184 != 0) {
+        int target = (((s16)(TJugemRodSignal::scSignalInterval & 0xFF) * 4) + TJugemRodSignal::sRandomWait) - 10;
+
+        if (mSignal->_188 == target) {
+            shouldSetState = true;
+        }
+    }
+    if (shouldSetState) {
+        setState(0xf);
+    }
+}
+
+void TJugem::initFunc_StartUp() {
+    startNextAnime();
+}
+
+void TJugem::doFunc_StartUp() {
+    move(getKartNum());
+
+    if (mIsAbleStart == false && ((s32)mSignal->_164.getFrameCtrl()->getFrame() == 7)) {
+        mIsAbleStart = true;
+    }
+    if (getStateCount() > sStartUpFrame) {
+        setState(0x10);
+    }
+}
+
+void TJugem::initFunc_StartWaitHide() {
+    _274 = 1;
+    mSplineInterp.restart();
+    mSplineInterp.setSpeed(sStartUpSpeed);
+}
+
+void TJugem::doFunc_StartWaitHide() {
+    move(getKartNum());
+    if (!mSplineInterp.checkUnknownBool13()) {
+        setState(1);
+    }
+}
+
+int TJugem::getSignalState() {
+    int signalState = -1;
+    switch (getState()) {
+        case 0xc:
+        case 0xd:
+        case 0xe:
+        case 0xf:
+            // Why is _17c declared as a `f32`, but used as an `s32` everywhere else...?
+            signalState = (s32)mSignal->_164.getFrameCtrl()->getFrame();
+    }
+    return signalState;
+}
+
+void TJugem::startNextAnime() {
+    mAnmPlayer._10 = 1;
+    mAnmPlayer._e |= 1;
+    TJugemItem *tJugemItem = mJugemItem;
+    if (tJugemItem == nullptr) {
+        return;
+    }
+    tJugemItem->mJugemAnmPlayer._10 = 1;
+    tJugemItem->mJugemAnmPlayer._e |= 1;
+}

--- a/src/Shiraiwa/JugemStart.cpp
+++ b/src/Shiraiwa/JugemStart.cpp
@@ -1,3 +1,4 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "Kaneshige/RaceMgr.h"
 #include "Shiraiwa/JugemMain.h"
 #include "Shiraiwa/JugemRodItem.h"

--- a/src/Shiraiwa/JugemVoidRod.cpp
+++ b/src/Shiraiwa/JugemVoidRod.cpp
@@ -1,0 +1,279 @@
+#include "JSystem/JGeometry/Matrix.h"
+#include "JSystem/JGeometry/Vec.h"
+#include "JSystem/JKernel/JKRHeap.h"
+#include "JSystem/JUtility/JUTAssert.h"
+#include "Sato/AnmController.h"
+#include "Shiraiwa/AnmPlayer.h"
+#include "Shiraiwa/JugemItem.h"
+#include "Shiraiwa/JugemMain.h"
+#include "Shiraiwa/JugemRodItem.h"
+#include "types.h"
+
+const s32 TJugemRodItem::cJugemRodItem_Max = 6;
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_Lap[4] = {
+    {"/Objects/rod_wz2fg.bca", nullptr, nullptr, 0, 30, 1, 1, 0},
+    {"/Objects/rod_lk.bca", nullptr, nullptr, 2, 30, 2, 2, 0},
+    {"/Objects/rod_by.bca", nullptr, nullptr, 2, 30, 2, 3, 0},
+    {"/Objects/rod_wz.bca", nullptr, nullptr, 2, 0, 0, 255, 0},
+};
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_Start[5] = {
+    {"/Objects/rod_th.bca", nullptr, nullptr, 0, 60, 1, 1, 0},
+    {"/Objects/rod_ww.bca", nullptr, nullptr, 2, 60, 0, 2, 0},
+    {"/Objects/rod_cd.bca", nullptr, nullptr, 0, 10, 1, 3, 0},
+    {"/Objects/rod_go.bca", nullptr, nullptr, 0, 60, 1, 4, 0},
+    {"/Objects/rod_wz.bca", nullptr, nullptr, 2, 0, 0, 255, 0},
+};
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_Reverse[2] = {
+    {"/Objects/rod_no.bca", nullptr, nullptr, 2, 30, 6, 1, 0},
+    {"/Objects/rod_st.bca", nullptr, nullptr, 2, 30, 6, 0, 0},
+};
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_Rescue[3] = {
+    { "/Objects/rod_ca.bca", nullptr, nullptr, 2, 0, 0, 1, 0 },
+    { "/Objects/rod_cu.bca", nullptr, nullptr, 0, 0, 0, 2, 0 },
+    { "/Objects/rod_wz.bca", nullptr, nullptr, 2, 0, 0, 255, 0 },
+};
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_Signal[3] = {
+    { "/Objects/jg_rod_in_a.bck", nullptr, nullptr, 0, 0, 1, 1, 0 },
+    { "/Objects/jg_rod_wait.bck", nullptr, nullptr, 2, 0, 0, 2, 0 },
+    { "/Objects/jg_rod_out.bck",  nullptr, nullptr, 0, 0, 1, 255, 0 },
+};
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_PukuS[3] = {
+    {"/Objects/jg_rod_in_b.bck", nullptr, nullptr, 0, 0, 1, 1, 0},
+    {"/Objects/jg_rod_wait.bck", nullptr, nullptr, 2, 0, 0, 2, 0},
+    {"/Objects/jg_rod_out.bck",  nullptr, nullptr, 0, 0, 1, 255, 0},
+};
+
+TAnmInfo TJugemVoidRod::sAnmInfos_Rod_PukuL[3] = {
+    { "/Objects/jg_rod_in_c.bck", nullptr, nullptr, 0, 0, 1, 1, 0 },
+    { "/Objects/jg_rod_wait.bck", nullptr, nullptr, 2, 0, 0, 2, 0 },
+    { "/Objects/jg_rod_out.bck",  nullptr, nullptr, 0, 0, 1, 255, 0 },
+};
+
+TJugemAnmTableEntry TJugemVoidRod::sAnmStateTable[4] = {
+    { sAnmInfos_Rod_Start, 5 },
+    { sAnmInfos_Rod_Lap, 4 },
+    { sAnmInfos_Rod_Rescue, 3 },
+    { sAnmInfos_Rod_Reverse, 2 },
+};
+
+TJugemAnmTableEntry TJugemVoidRod::sDemoAnmStateTable[3] = {
+    { sAnmInfos_Rod_Signal, 3 },
+    { sAnmInfos_Rod_PukuS, 3 },
+    { sAnmInfos_Rod_PukuL, 3 },
+};
+
+
+TJugemVoidRod::TJugemVoidRod() : TJugemItem(0x101) {
+    _184 = nullptr;
+    if (TJugem::isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            mDemoRodAnmController[i] = new AnmController();
+        }
+    } else {
+        for (int i = 0; i < 4; i++) {
+            mRodAnmController[i] = new AnmController();
+        }
+    }
+
+    reset();
+
+    for (int i = 0; i < TJugemRodItem::cJugemRodItem_Max; i++) {
+        _188[i] = nullptr;
+    }
+    
+    if (TJugem::isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            TAnmPlayer::resetAnimations(sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize);
+        }
+    } else {
+        for (int i = 0; i < 4; i++) {
+            TAnmPlayer::resetAnimations(sAnmStateTable[i].tAnmInfo, sAnmStateTable[i].arraySize);
+        }
+    }
+}
+
+TJugemVoidRod::~TJugemVoidRod() {
+    if (TJugem::isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            delete mDemoRodAnmController[i];
+        }
+    } else {
+        for (int i = 0; i < 4; i++) {
+            delete mRodAnmController[i];
+        }
+    }
+}
+
+void TJugemVoidRod::reset() {
+    resetObject();
+    _58 = 0;
+    clrAllCheckKartHitFlag();
+    clrObjFlagCheckGeoHitting();
+    clrObjFlagCheckItemHitting();
+    setObjFlagHidding();
+    if (_184 != nullptr) {
+        _184->hide();
+    }
+}
+
+void TJugemRodItem::hide() {
+    setObjFlagHidding();
+}
+
+void TJugemVoidRod::loadAnimation() {
+    J3DModelData *modelData = mModel.getModelData();
+    if (TJugem::isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            TAnmPlayer::loadAnimations(sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize, modelData, ResMgr::mcArcOpening);
+        }
+    } else {
+        for (int i = 0; i < 4; i++) {
+            TAnmPlayer::loadAnimations(sAnmStateTable[i].tAnmInfo, sAnmStateTable[i].arraySize, modelData, ResMgr::mcArcMRAM);
+        }
+    }
+}
+
+const char *TJugemVoidRod::getShadowBmdFileName() {
+    return NULL;
+}
+
+const char *TJugemVoidRod::getBmdFileName() {
+    static const char *cBmdName = "/Objects/rod_model.bmd";
+    return cBmdName;
+}
+
+void TJugemVoidRod::createModel(JKRSolidHeap *jkrSolidHeap, u32 param_2) {
+    mModel.createModel(jkrSolidHeap, param_2, 0);
+
+    _1a4 = mModel.getModelData()->getJointName()->getIndex("ef_hook");
+    J3DJoint* joint = mModel.getModelData()->getJointNodePointer(_1a4);
+    joint->setCallBack(nodeCallBack);
+
+    mModel._14 = nullptr;
+    if (TJugem::isDemoMode()) {
+        for (int i = 0; i < 3; i++) {
+            TAnmPlayer::registAnimations(mDemoRodAnmController[i], &mModel, sDemoAnmStateTable[i].tAnmInfo, sDemoAnmStateTable[i].arraySize);
+        }
+    } else {
+        for (int i = 0; i < 4; i++) {
+            TAnmPlayer::registAnimations(mRodAnmController[i], &mModel, sAnmStateTable[i].tAnmInfo, sAnmStateTable[i].arraySize);
+        }
+    }
+}
+
+void TJugemVoidRod::calc() {
+    if (!tstObjFlagHidding()) {
+        mJugemAnmPlayer.update();
+    }
+}
+
+void TJugemVoidRod::createColModel(J3DModelData *j3dModelData) {}
+
+void TJugemVoidRod::hideModel(u32 param_1) {
+    mModel.clipAll(param_1, false);
+    if (_184 != nullptr) {
+        _184->mModel.clipAll(param_1, false);
+    }
+}
+
+void TJugemVoidRod::show(u8 param_1) {
+    clrObjFlagHidding();
+    if (_184 != nullptr) {
+        _184->show(param_1);
+    }
+}
+
+void TJugemRodItem::show(u8) {
+    clrObjFlagHidding();
+}
+
+void TJugemVoidRod::update() {
+    setModelMatrixAndScale();
+    mModel.update(0);
+}
+
+void TJugemVoidRod::hide() {
+    setObjFlagHidding();
+    if (_184 != nullptr) {
+        _184->hide();
+    }
+}
+
+void TJugemVoidRod::hideAll() {
+    setObjFlagHidding();
+    for (int i = 0; i < TJugemRodItem::cJugemRodItem_Max; i++) {
+        if (_188[i] != nullptr) {
+            _188[i]->hideAll();
+        }
+    }
+}
+
+void TJugemVoidRod::setJugemRodItem(TJugemRodItem *rodItem, u32 type) {
+    #line 341
+    JUT_ASSERT_MSG(type < TJugemRodItem::cJugemRodItem_Max, "id < TJugemRodItem::cJugemRodItem_Max");
+    _188[type] = rodItem;
+}
+
+void TJugemVoidRod::hold(u32 id) {
+    if (_184 != nullptr) {
+        _184->hide();
+    }
+#line 356
+    JUT_ASSERT_MSG(id < TJugemRodItem::cJugemRodItem_Max, "id < TJugemRodItem::cJugemRodItem_Max");
+    if (id == 0) {
+        _184 = nullptr;
+    } else if (_188[id] != nullptr) {
+        _184 = _188[id];
+    }
+    mModel._14 = (u32 *)_184;
+}
+
+void TJugemVoidRod::changeAnimation(u32 type) {
+    if (TJugem::isDemoMode()) {
+        #line 376
+        JUT_MINMAX_ASSERT(0, type, 3);
+        mAnmCtrl = mDemoRodAnmController[type];
+        mJugemAnmPlayer.init(mDemoRodAnmController[type], sDemoAnmStateTable[type].tAnmInfo, sDemoAnmStateTable[type].arraySize);
+    } else {
+        #line 380
+        JUT_MINMAX_ASSERT(0, type, 4);
+        mAnmCtrl = mRodAnmController[type];
+        mJugemAnmPlayer.init(mRodAnmController[type], sAnmStateTable[type].tAnmInfo, sAnmStateTable[type].arraySize);
+    }
+
+    if (mAnmCtrl->IsAvailableTrans()) {
+        mAnmCtrl->StopTrans();
+    }
+}
+
+bool TJugemVoidRod::nodeCallBack(J3DJoint *joint, int param_2) {
+    if (!param_2) {
+        u16 jointIndex = joint->mJointIdx;
+
+        J3DModel *model = j3dSys._38;
+        J3DModelData *modelData = model->mModelData;
+
+        // FIX: This is almost certainly wrong.
+        //      Need to find out what casts to use to make this work correctly.
+        TJugemVoidRod *obj = (TJugemVoidRod *)((ExModel *)model->getUserArea())->_14;
+        if (obj) {
+            Mtx& mtx = model->getAnmMtx(jointIndex);
+
+            JGeometry::TPos3f copy;
+            copy.set(mtx);
+
+            JGeometry::TVec3f pos;
+            pos.set(mtx[0][3], mtx[1][3], mtx[2][3]);
+
+            obj->setPosition(pos);   // 0x80
+            obj->setRMtx(copy);      // 0x84
+        }
+    }
+    return true;
+}

--- a/src/Shiraiwa/JugemVoidRod.cpp
+++ b/src/Shiraiwa/JugemVoidRod.cpp
@@ -1,3 +1,4 @@
+#include "JSystem/JAudio/JASFakeMatch2.h"
 #include "JSystem/JGeometry/Matrix.h"
 #include "JSystem/JGeometry/Vec.h"
 #include "JSystem/JKernel/JKRHeap.h"


### PR DESCRIPTION
This is the majority of the `Jugem` classes decompiled.

"Jugem" seems to be responsible for a number of Lakitu related game actions and animations.

@SwareJonge - as mentioned, I've had some issues especially with the `nodeCallBack` functions in this section. I think I've done all I can here for now, so please let me know if there is anything else you need me to do.

## Remaining Issues in Jugem Classes:
1. All of the `nodeCallBack` functions (just search `nodeCallBack` globally, you'll find them pretty quickly) where the datatype to cast to is not obvious.

2. Quaternion related strangeness in `TJugem::localMove` function in JugemMain.cpp, as there's a missing init of some sort below `static JGeometry::TQuat4f qtAxisY;`. (I've left some commented out code to show what should be there.)

3. In JugemReverse, `TJugem::doFunc_Reverse()` has a call to `GameAudio::Main::msBasic` in the wrong spot for some reason, and I can't work out why.

4. The `TJugemRodPukuPuku::createModel` function also has loads from `nodeCallBack` and `sDemoAnmStateTable` swapped around in the assembly output. Again, not sure why.

5. Registers are wrong in a few places, but they look like upstream issues for most of them.

6. `inline void JGeometry::TRot3f::setRotate(const TVec3f &a, const TVec3f &b)` - Whenever I try and implement this function, it throws `TJugem::resetJugemOrigin()` out of whack. I get that `resetJugemOrigin` probably uses the default JGeometry `setRotate` function, and some other function probably uses the local templated version of setRotate, but I've not been able to figure this one out either. Note that I've already done my best to pull code from other decomps such as Super Mario Galaxy, but I've had limited success doing so.