### PR TITLE
NMWException: Implement remaining functions and mark as matching.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -381,7 +381,7 @@ config.libs = [
             Object(Matching, "Runtime/__mem.c"),
             Object(Matching, "Runtime/__va_arg.c"),
             Object(Matching, "Runtime/global_destructor_chain.c"),
-            Object(NonMatching, "Runtime/NMWException.cp"),
+            Object(Matching, "Runtime/NMWException.cp"),
             Object(Matching, "Runtime/CPlusLibPPC.cp"),
             Object(Matching, "Runtime/ptmf.c"),
             Object(Matching, "Runtime/runtime.c"),

--- a/libs/PowerPC_EABI_Support/include/PowerPC_EABI_Support/Runtime/MWCPlusPlusLib.h
+++ b/libs/PowerPC_EABI_Support/include/PowerPC_EABI_Support/Runtime/MWCPlusPlusLib.h
@@ -19,7 +19,7 @@ extern "C"
 #define DTORCALL_COMPLETE(dtor, objptr) (((void (*)(void *, DTORARG_TYPE))dtor)(objptr, -1))
 #define DTORCALL_PARTIAL(dtor, objptr) (((void (*)(void *, DTORARG_TYPE))dtor)(objptr, 0))
 
-typedef void *ConstructorDestructor;
+typedef void (*ConstructorDestructor)(size_t *, int);
 
 typedef struct PTMF
 {
@@ -34,7 +34,11 @@ typedef struct PTMF
 
 extern void __construct_array(void *ptr, ConstructorDestructor ctor, ConstructorDestructor dtor, size_t size, size_t n);
 extern void __destroy_arr(void *block, ConstructorDestructor *dtor, size_t size, size_t n);
-extern void *__construct_new_array(void *block, ConstructorDestructor ctor, ConstructorDestructor dtor_arg, size_t size, size_t n);
+extern void *__construct_new_array(size_t *block,
+                                   ConstructorDestructor ctor,
+                                   ConstructorDestructor dtor_arg,
+                                   size_t size,
+                                   size_t n);
 extern void __destroy_new_array(void *block, ConstructorDestructor dtor);
 extern void __destroy_new_array2();
 extern void __destroy_new_array3();

--- a/libs/PowerPC_EABI_Support/src/Runtime/NMWException.cp
+++ b/libs/PowerPC_EABI_Support/src/Runtime/NMWException.cp
@@ -1,90 +1,123 @@
-#include "PowerPC_EABI_Support/Runtime/NMWException.h"
 #include "PowerPC_EABI_Support/Runtime/MWCPlusPlusLib.h"
 
 #pragma exceptions on
 
-extern "C"
-{
-	void abort();
-}
-
-namespace std
-{
-	static void dthandler()
-	{
-		abort();
-	}
-
-	terminate_handler thandler = dthandler;
-
-	static void duhandler()
-	{
-		terminate();
-	}
-
-	unexpected_handler uhandler = duhandler;
-
-	extern void terminate()
-	{
-		thandler();
-	}	
-
-	extern void unexpected() {
-		uhandler();
-	}
-}
-
-extern "C" char __throw_catch_compare(const char* throwtype, const char* catchtype, s32* offset_result) {
-
-}
-
-extern "C" void *__construct_new_array(void *block, ConstructorDestructor ctor, ConstructorDestructor dtor_arg, size_t size, size_t n)
-{
-
-}
+#define ARRAY_HEADER_SIZE 16
 
 class __partial_array_destructor
 {
 private:
-	void *p;
-	size_t size;
-	size_t n;
-	void *dtor;
+    void *p;
+    size_t size;
+    size_t n;
+    ConstructorDestructor dtor;
 
 public:
-	size_t i;
+    size_t i;
 
-	__partial_array_destructor(void *array, size_t elementsize, size_t nelements, void *destructor)
-	{
-		p = array;
-		size = elementsize;
-		n = nelements;
-		dtor = destructor;
-		i = n;
-	}
+    __partial_array_destructor(void *array,
+                               size_t elementsize,
+                               size_t nelements,
+                               ConstructorDestructor destructor)
+    {
+        p = array;
+        size = elementsize;
+        n = nelements;
+        dtor = destructor;
+        i = n;
+    }
 
-	~__partial_array_destructor()
-	{
-		char *ptr;
+    ~__partial_array_destructor()
+    {
+        char *ptr;
 
-		if (i < n && dtor)
-		{
-			for (ptr = (char *)p + size * i; i > 0; i--)
-			{
-				ptr -= size;
-				DTORCALL_COMPLETE(dtor, ptr);
-			}
-		}
-	}
+        if (i < n && dtor)
+        {
+            for (ptr = (char *)p + size * i; i > 0; i--)
+            {
+                ptr -= size;
+                DTORCALL_COMPLETE(dtor, ptr);
+            }
+        }
+    }
 };
 
-
-extern "C" void __construct_array(void *ptr, void *ctor, void *dtor, size_t size, size_t n)
+extern "C" void *__construct_new_array(size_t *block,
+                                       ConstructorDestructor ctor,
+                                       ConstructorDestructor dtor,
+                                       size_t size,
+                                       size_t n)
 {
+    char *ptr;
 
+    if ((ptr = (char *)block) != 0L)
+    {
+        size_t *p = (size_t *)ptr;
+
+        p[0] = size;
+        p[1] = n;
+        ptr += ARRAY_HEADER_SIZE;
+
+        if (ctor)
+        {
+            __partial_array_destructor pad(ptr, size, n, dtor);
+            char *p;
+
+            for (pad.i = 0, p = (char *)ptr; pad.i < n; pad.i++, p += size)
+            {
+                CTORCALL_COMPLETE(ctor, p);
+            }
+        }
+    }
+    return ptr;
 }
 
-extern "C" void __destroy_arr(void *block, ConstructorDestructor *dtor, size_t size, size_t n)
+extern void __construct_array(void *ptr,
+                              ConstructorDestructor ctor,
+                              ConstructorDestructor dtor,
+                              size_t size,
+                              size_t n)
 {
+    __partial_array_destructor pad(ptr, size, n, dtor);
+    char *p;
 
+    for (pad.i = 0, p = (char *)ptr; pad.i < n; pad.i++, p += size)
+    {
+        CTORCALL_COMPLETE(ctor, p);
+    }
+}
+
+extern void __destroy_arr(void *block, ConstructorDestructor *dtor, size_t size, size_t n)
+{
+    char *p;
+
+    for (p = (char *)block + size * n; n > 0; n--)
+    {
+        p -= size;
+        DTORCALL_COMPLETE(dtor, p);
+    }
+}
+
+extern void __destroy_new_array(void *block, ConstructorDestructor dtor)
+{
+    if (block)
+    {
+        if (dtor)
+        {
+            size_t i, objects, objectsize;
+            char *p;
+
+            objectsize = *(size_t *)((char *)block - ARRAY_HEADER_SIZE);
+            objects = ((size_t *)((char *)block - ARRAY_HEADER_SIZE))[1];
+            p = (char *)block + (objectsize * objects);
+
+            for (i = 0; i < objects; i++)
+            {
+                p -= objectsize;
+                DTORCALL_COMPLETE(dtor, p);
+            }
+        }
+
+        ::operator delete[]((char *)block - ARRAY_HEADER_SIZE);
+    }
 }


### PR DESCRIPTION
Besides a few tweaks (e.g. `ARRAY_HEADER_SIZE` is twice as large), the implementations have been taken from the _Super Mario Sunshine_ decompilation project.