### PR TITLE
animator: Force data ordering and mark as matching.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1230,7 +1230,7 @@ config.libs = [
         [],
         [
             Object(Matching, "Osako/clock.cpp"),
-            Object(NonMatching, "Osako/animator.cpp"),
+            Object(Matching, "Osako/animator.cpp"),
             Object(Matching, "Osako/testApp.cpp"),
             Object(Matching, "Osako/shadowModel.cpp"),
             Object(Matching, "Osako/GameApp.cpp"),

--- a/src/Osako/animator.cpp
+++ b/src/Osako/animator.cpp
@@ -1,5 +1,10 @@
 #include "Osako/animator.h"
 
+static void unused_force_data_ordering(double *a)
+{
+    *a = 4503601774854144.0;
+}
+
 void AnimatorWind::start() {
     mAnimationState = 1;
 }
@@ -10,7 +15,13 @@ void AnimatorWind::stop() {
 
 void AnimatorWind::reset() {
     mAnimationState = 0;
-    mFrameCounter = 0;
+    mFrameCounter = 0.0f;
+}
+
+static void unused_force_data_ordering2(float *a)
+{
+    *a = 0.0f;
+    *a = 60.0f;
 }
 
 void LoopAnimatorWind::update() {


### PR DESCRIPTION
The theory is that data ordering was altered by _unused_ functions that were part of the compilation in the original game but were ultimately stripped of the binary. The symbols do not appear in the program, but the data remains.

The solution is to define a counter unused function that defines the data in the order in which it appears in the original data section.