### PR TITLE
Add option for symbols order check during ninja build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -26,6 +26,8 @@ from tools.project import (
     is_windows,
 )
 
+from tools.dev_symbols_order_check import configure_symbols_order_check
+
 # Game versions
 DEFAULT_VERSION = 0
 VERSIONS = [
@@ -77,6 +79,11 @@ parser.add_argument(
     "--debug",
     action="store_true",
     help="build with debug info (non-matching)",
+)
+parser.add_argument(
+    "--check-symbols-order",
+    action="store_true",
+    help="add symbols order check at the end of the build"
 )
 if not is_windows():
     parser.add_argument(
@@ -142,6 +149,9 @@ version_num = VERSIONS.index(config.version)
 debug = args.debug
 if config.version == "MarioClub_us":
     debug = True
+
+if args.check_symbols_order:
+    configure_symbols_order_check(config)
 
 # Apply arguments
 config.build_dir = args.build_dir

--- a/tools/dev_symbols_order_check.py
+++ b/tools/dev_symbols_order_check.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+###
+# Helper file to add custom rules to the ninja build in order to check the symbols order at the
+# end of the build.
+# It adds:
+# - post-build check of the symbols order of all modified cpp files found in git against main branch
+# This is to automate the symbols check in the workflow and ease the developer experience.
+###
+
+import subprocess
+import sys
+from pathlib import Path
+
+def configure_symbols_order_check(
+        config) -> None:
+    """Add custom rules to the project in order to check automatically
+    the symbols order with the current git diff."""
+
+    map_out = f"orig/{config.version}/files/debugInfoM.MAP"
+
+    config.custom_build_rules = [
+        {
+            "name": "check_symbols_order",
+            "command": "python3 tools/dev_symbols_order_check.py",
+            "description": "CHECK symbols order",
+            "pool": "console",
+        },
+    ]
+
+    config.custom_build_steps = {
+        "post-build": [
+            {
+                "rule": "check_symbols_order",
+                "outputs": "check_symbols_order.stamp",
+                "implicit": [map_out],
+            },
+        ],
+    }
+
+def get_changed_cpp_files(base="main"):
+    """Helper function performing a git diff against a given branch
+    in order to find which cpp files changed."""
+    merge_base = subprocess.check_output(
+        ["git", "merge-base", base, "HEAD"], text=True
+    ).strip()
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", merge_base, "--", "*.cpp"], text=True
+    )
+    return out.split()
+
+def main() -> int:
+    """Perform a git diff and run the symbol order check on all found cpp files.
+    This main will be used during ninja build phase configured in 'configure_symbol_order_check'.
+    """
+    changed = get_changed_cpp_files()
+    if not changed:
+        print("No changed .cpp files vs main — nothing to check.")
+        return 0
+
+    script = Path(__file__).parent / "check-changed-symbol-order.py"
+    return subprocess.call([sys.executable, str(script), *changed])
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate-symbol-order.py
+++ b/tools/validate-symbol-order.py
@@ -62,8 +62,12 @@ from typing import Dict, List, Optional, Tuple
 script_dir = os.path.dirname(os.path.realpath(__file__))
 root_dir = os.path.abspath(os.path.join(script_dir, ".."))
 
+def is_windows() -> bool:
+    return os.name == "nt"
+
+EXE = ".exe" if is_windows() else ""
 DEFAULT_MAP = os.path.join(root_dir, "orig", "MarioClub_us", "files", "debugInfoM.MAP")
-NM = os.environ.get("NM", os.path.join(root_dir, "build", "binutils", "powerpc-eabi-nm.exe"))
+NM = os.environ.get("NM", os.path.join(root_dir, "build", "binutils", f"powerpc-eabi-nm{EXE}"))
 OBJDIFF_JSON = os.path.join(root_dir, "objdiff.json")
 
 


### PR DESCRIPTION
- Add an option `configure.py` file to automatically add symbols order check during ninja build
- Modify `tools/validate-symbol-order.py` in order to set `NM` default variable as platform agnostic